### PR TITLE
[New Unit] Lottery Tank

### DIFF
--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -26,6 +26,7 @@ void GameCore::GeneratePrimaryUnitList() {
   ADD_SELECTABLE_UNIT(unit::ThreeBodyMan);
   ADD_SELECTABLE_UNIT(unit::InfernoTank);
   ADD_SELECTABLE_UNIT(unit::WhaoooooTank);
+  ADD_SELECTABLE_UNIT(unit::LotteryTank);
 
   unit.reset();
 }

--- a/src/battle_game/core/units/lottery_tank.cpp
+++ b/src/battle_game/core/units/lottery_tank.cpp
@@ -1,0 +1,236 @@
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+#include "lottery_tank.h"
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+LotteryTank::LotteryTank(GameCore *game_core, uint32_t id, uint32_t player_id)
+    : Unit(game_core, id, player_id) {
+  if (!~tank_body_model_index) {
+    auto mgr = AssetsManager::GetInstance();
+    {
+      /* Tank Body */
+      tank_body_model_index = mgr->RegisterModel(
+          {
+              {{-0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              // distinguish front and back
+              {{0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+          },
+          {0, 1, 2, 1, 2, 3, 0, 2, 5, 2, 4, 5});
+    }
+
+    {
+      /* Tank Turret */
+      std::vector<ObjectVertex> turret_vertices;
+      std::vector<uint32_t> turret_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        turret_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
+                                   {0.0f, 0.0f},
+                                   {0.7f, 0.7f, 0.7f, 1.0f}});
+        turret_indices.push_back(i);
+        turret_indices.push_back((i + 1) % precision);
+        turret_indices.push_back(precision);
+      }
+      turret_vertices.push_back(
+          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_indices.push_back(precision + 1 + 0);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 3);
+      tank_turret_model_index =
+          mgr->RegisterModel(turret_vertices, turret_indices);
+    }
+  }
+}
+
+void LotteryTank::Render() {
+  battle_game::SetTransformation(position_, rotation_);
+  battle_game::SetTexture(0);
+  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
+  battle_game::DrawModel(tank_body_model_index);
+  battle_game::SetRotation(turret_rotation_);
+  battle_game::DrawModel(tank_turret_model_index);
+}
+
+void LotteryTank::Update() {
+  TankMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Fire();
+}
+
+void LotteryTank::TankMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    glm::vec2 offset{0.0f};
+    if (input_data.key_down[GLFW_KEY_W]) {
+      offset.y += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_S]) {
+      offset.y -= 1.0f;
+    }
+    float speed = move_speed * GetSpeedScale();
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    }
+    float rotation_offset = 0.0f;
+    if (input_data.key_down[GLFW_KEY_A]) {
+      rotation_offset += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_D]) {
+      rotation_offset -= 1.0f;
+    }
+    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+void LotteryTank::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    auto diff = input_data.mouse_cursor_position - position_;
+    if (glm::length(diff) < 1e-4) {
+      turret_rotation_ = rotation_;
+    } else {
+      turret_rotation_ = std::atan2(diff.y, diff.x) - glm::radians(90.0f);
+    }
+  }
+}
+
+void LotteryTank::Fire() {
+  if (fire_count_down_) {
+    fire_count_down_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+          switch (GetBulletType()) { 
+          case BigScatter:
+            ScatterFire(ScatterBulletsCount, true);
+            break;
+          case Scatter:
+            ScatterFire(ScatterBulletsCount, false);
+            break;
+          case Big:
+            ScatterFire(NormalBulletsCount, true);
+            break;
+          case Normal:
+          dafault:
+            ScatterFire(NormalBulletsCount, false);
+            break;
+        }
+        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+      }
+    }
+  }
+}
+
+bool LotteryTank::IsHit(glm::vec2 position) const {
+  position = WorldToLocal(position);
+  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
+         position.y < 1.0f && position.x + position.y < 1.6f &&
+         position.y - position.x < 1.6f;
+}
+
+bool LotteryTank::IsBig() {
+  return CardLottery(GetNormalTimes, InitProb_Big, BigBulletFloor,
+                     BigBulletCeil);
+}
+
+bool LotteryTank::IsScatter() {
+  return CardLottery(GetOnceTimes, InitProb_Scatter, ScatterBulletFloor,
+                     ScatterBulletCeil);
+}
+
+LotteryTank::BulletType LotteryTank::GetBulletType() {
+  uint32_t Type = IsBig() | (IsScatter() << 1);
+  if (Type & 1)
+    GetNormalTimes = 0;
+  else
+    ++GetNormalTimes;
+
+  if (Type & 2)
+    GetOnceTimes = 0;
+  else
+    ++GetOnceTimes;
+  
+  switch (Type) { 
+    case 1:
+      return Big;
+    case 2:
+      return Scatter;
+    case 3:
+      return BigScatter;
+    default:
+      return Normal;
+  }
+}
+
+void LotteryTank::ScatterFire(uint32_t BulletsCount, bool IsBig) {
+  auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+  float Damage = GetDamageScale() * (IsBig ? BigDamageRange : NormalDamageRange);
+  int lim = BulletsCount - 1;
+  for (int i = -lim; i <= lim; i += 2) {
+    auto offset = glm::radians(3.0f * i);
+    velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_ + offset);
+    if (IsBig)
+      GenerateBullet<bullet::Rocket>(
+          position_ + Rotate({0.0f, 1.2f}, turret_rotation_ + offset),
+          turret_rotation_ + offset, Damage, velocity);
+    else
+      GenerateBullet<bullet::CannonBall>(
+        position_ + Rotate({0.0f, 1.2f}, turret_rotation_ + offset),
+        turret_rotation_ + offset, Damage, velocity);
+  }
+}
+
+uint32_t LotteryTank::MinusClamp(uint32_t x, uint32_t y, uint32_t floor) {
+  return x < y + floor ? floor : x - y;
+}
+
+bool LotteryTank::CardLottery(uint32_t times, float init_prob, uint32_t floor, uint32_t ceil) {
+  float rand_num_ = game_core_->RandomFloat();
+  return rand_num_ <= init_prob + (1.0f - init_prob) * (MinusClamp(times, floor, 0) * 1.0f / MinusClamp(ceil, floor, 1)) ;
+}
+
+const char *LotteryTank::UnitName() const {
+  return "Lottery Tank";
+}
+
+const char *LotteryTank::Author() const {
+  return "JasonL";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/lottery_tank.h
+++ b/src/battle_game/core/units/lottery_tank.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "battle_game/core/unit.h"
+
+namespace battle_game::unit {
+class LotteryTank : public Unit {
+ public:
+  LotteryTank(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+
+ protected:
+
+  //Basic Settings
+  void TankMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+  float turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+
+  // Bullet Settings
+  enum BulletType {
+	  Normal = 0,	//1.0x
+	  Big,			//10.0x
+	  Scatter,		//1.0x, 5 bullets
+	  BigScatter	//10.0x, 5 bullets
+  };
+  const float NormalDamageRange{1.0f};
+  const float BigDamageRange{10.0f};
+  const uint32_t NormalBulletsCount{1};
+  const uint32_t ScatterBulletsCount{5};
+  bool IsBig();
+  bool IsScatter();
+  BulletType GetBulletType();
+  void ScatterFire(uint32_t BulletsCount, bool IsBig);
+
+  //Lottery Probability Settings
+  uint32_t GetNormalTimes{0};
+  uint32_t GetOnceTimes{0};
+  const uint32_t BigBulletFloor{10};
+  const uint32_t BigBulletCeil{20};
+  const uint32_t ScatterBulletFloor{20};
+  const uint32_t ScatterBulletCeil{50};
+  const float InitProb_Big{0.2f};
+  const float InitProb_Scatter{0.02f};
+  uint32_t MinusClamp(uint32_t x, uint32_t y, uint32_t floor);
+  bool CardLottery(uint32_t times, float init_prob, uint32_t floor, uint32_t ceil);
+};
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -3,4 +3,5 @@
 #include "battle_game/core/units/double_scatter_tank.h"
 #include "battle_game/core/units/inferno_tank.h"
 #include "battle_game/core/units/three_body_man.h"
+#include "battle_game/core/units/lottery_tank.h"
 #include "battle_game/core/units/tiny_tank.h"


### PR DESCRIPTION
一个基于初始模型的简单“抽奖”坦克。仿照某些游戏的抽卡机制设计了不同的子弹buff。
第一种是子弹伤害倍率变大（10倍），20%几率抽到，10次未抽中开始增加概率，第20次必中。
第二种是子弹变为散射（5发），2%几率抽到，20次未抽中开始增加概率，第50次必中。
开火间隔为 1s。