### PR TITLE
CRIT effect in bullet shuriken

### DIFF
--- a/src/battle_game/core/bullet.h
+++ b/src/battle_game/core/bullet.h
@@ -20,5 +20,6 @@ class Bullet : public Object {
   uint32_t unit_id_{};
   uint32_t player_id_{};
   float damage_scale_{1.0f};
+  float CRIT_rate = 0.3;
 };
 }  // namespace battle_game

--- a/src/battle_game/core/bullet.h
+++ b/src/battle_game/core/bullet.h
@@ -20,6 +20,5 @@ class Bullet : public Object {
   uint32_t unit_id_{};
   uint32_t player_id_{};
   float damage_scale_{1.0f};
-  float CRIT_rate = 0.3;
 };
 }  // namespace battle_game

--- a/src/battle_game/core/bullets/bullets.h
+++ b/src/battle_game/core/bullets/bullets.h
@@ -3,5 +3,6 @@
 #include "battle_game/core/bullets/cannon_ball.h"
 #include "battle_game/core/bullets/missile.h"
 #include "battle_game/core/bullets/rocket.h"
+#include "battle_game/core/bullets/shuriken.h"
 #include "battle_game/core/bullets/warning_line.h"
 #include "battle_game/core/bullets/water_drop.h"

--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -38,6 +38,7 @@ void GameCore::GeneratePrimaryUnitList() {
   ADD_SELECTABLE_UNIT(unit::TankXxy);
   ADD_SELECTABLE_UNIT(unit::WhaoooooTank);
   ADD_SELECTABLE_UNIT(unit::SquareTank);
+  ADD_SELECTABLE_UNIT(unit::ElementaryTank);
 
   unit.reset();
 }

--- a/src/battle_game/core/units/elementary_tank.cpp
+++ b/src/battle_game/core/units/elementary_tank.cpp
@@ -1,0 +1,207 @@
+#include "elementary_tank.h"
+
+#include <ctime>
+
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+#include "tiny_tank.h"
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+ElementaryTank::ElementaryTank(GameCore *game_core,
+                               uint32_t id,
+                               uint32_t player_id)
+    : Unit(game_core, id, player_id) {
+  if (!~tank_body_model_index) {
+    auto mgr = AssetsManager::GetInstance();
+    {
+      /* Tank Body */
+      tank_body_model_index = mgr->RegisterModel(
+          {
+              {{-0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              // distinguish front and back
+              {{0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+          },
+          {0, 1, 2, 1, 2, 3, 0, 2, 5, 2, 4, 5});
+    }
+
+    {
+      /* Tank Turret */
+      std::vector<ObjectVertex> turret_vertices;
+      std::vector<uint32_t> turret_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        turret_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
+                                   {0.0f, 0.0f},
+                                   {0.7f, 0.7f, 0.7f, 1.0f}});
+        turret_indices.push_back(i);
+        turret_indices.push_back((i + 1) % precision);
+        turret_indices.push_back(precision);
+      }
+      turret_vertices.push_back(
+          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_indices.push_back(precision + 1 + 0);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 3);
+      tank_turret_model_index =
+          mgr->RegisterModel(turret_vertices, turret_indices);
+    }
+  }
+  Skill tmp;
+  tmp.name = "Accelerate";
+  tmp.time_remain = 0;
+  tmp.time_total = 700;
+  tmp.type = Q;
+  tmp.function = SKILL_ADD_FUNCTION(ElementaryTank::Accelerate);
+  skills_.push_back(tmp);
+}
+
+void ElementaryTank::Render() {
+  battle_game::SetTransformation(position_, rotation_);
+  battle_game::SetTexture(0);
+  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
+  battle_game::DrawModel(tank_body_model_index);
+  battle_game::SetRotation(turret_rotation_);
+  battle_game::DrawModel(tank_turret_model_index);
+}
+
+void ElementaryTank::Update() {
+  TankMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Accelerate();
+  Fire();
+}
+
+void ElementaryTank::TankMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    glm::vec2 offset{0.0f};
+    if (input_data.key_down[GLFW_KEY_W]) {
+      offset.y += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_S]) {
+      offset.y -= 1.0f;
+    }
+    float speed = move_speed * GetSpeedScale();
+    if (accelerate_flag)
+      speed *= 2;
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    }
+    float rotation_offset = 0.0f;
+    if (input_data.key_down[GLFW_KEY_A]) {
+      rotation_offset += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_D]) {
+      rotation_offset -= 1.0f;
+    }
+    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+void ElementaryTank::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    auto diff = input_data.mouse_cursor_position - position_;
+    if (glm::length(diff) < 1e-4) {
+      turret_rotation_ = rotation_;
+    } else {
+      turret_rotation_ = std::atan2(diff.y, diff.x) - glm::radians(90.0f);
+    }
+  }
+}
+
+void ElementaryTank::Accelerate() {
+  if (accelerate_time <= 360)
+    accelerate_time += 1;
+  else
+    accelerate_flag = FALSE;
+  if (skills_[0].time_remain) {
+    skills_[0].time_remain -= 1;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.key_down[GLFW_KEY_Q]) {
+        accelerate_flag = TRUE;
+        accelerate_time = 0;
+        skills_[0].time_remain = skills_[0].time_total;
+        num_strong_bullets = 3;
+      }
+    }
+  }
+}
+
+void ElementaryTank::Fire() {
+  if (fire_count_down_) {
+    fire_count_down_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+        if (num_strong_bullets) {
+          GenerateBullet<bullet::Rocket>(
+              position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+              turret_rotation_, GetDamageScale(), velocity);
+          num_strong_bullets -= 1;
+        } else
+          GenerateBullet<bullet::CannonBall>(
+              position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+              turret_rotation_, GetDamageScale(), velocity);
+        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+      }
+    }
+  }
+}
+
+bool ElementaryTank::IsHit(glm::vec2 position) const {
+  position = WorldToLocal(position);
+  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
+         position.y < 1.0f && position.x + position.y < 1.6f &&
+         position.y - position.x < 1.6f;
+}
+
+const char *ElementaryTank::UnitName() const {
+  return "Elementary Tank";
+}
+
+const char *ElementaryTank::Author() const {
+  return "Wzrrr";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/elementary_tank.cpp
+++ b/src/battle_game/core/units/elementary_tank.cpp
@@ -216,6 +216,7 @@ void ElementaryTank::Fire() {
               turret_rotation_, GetDamageScale(), velocity);
           num_strong_bullets -= 1;
         } else
+
           GenerateBullet<bullet::CannonBall>(
               position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
               turret_rotation_, GetDamageScale(), velocity);

--- a/src/battle_game/core/units/elementary_tank.cpp
+++ b/src/battle_game/core/units/elementary_tank.cpp
@@ -215,14 +215,18 @@ void ElementaryTank::Fire() {
               position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
               turret_rotation_, GetDamageScale(), velocity);
           num_strong_bullets -= 1;
-        } else
-          GenerateBullet<bullet::CannonBall>(
-              position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
-              turret_rotation_, GetDamageScale(), velocity);
-        if (rageshoot_flag)
           fire_count_down_ = kTickPerSecond * 0.5;
-        else
+        } else if (rageshoot_flag) {
+          GenerateBullet<bullet::Shuriken>(
+              position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+              turret_rotation_, GetDamageScale(), velocity, true);
+          fire_count_down_ = kTickPerSecond * 0.25;
+        } else {
+          GenerateBullet<bullet::Shuriken>(
+              position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+              turret_rotation_, GetDamageScale(), velocity, false);
           fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+        }
       }
     }
   }

--- a/src/battle_game/core/units/elementary_tank.cpp
+++ b/src/battle_game/core/units/elementary_tank.cpp
@@ -149,7 +149,7 @@ void ElementaryTank::Accelerate() {
   if (accelerate_time <= 360)
     accelerate_time += 1;
   else
-    accelerate_flag = FALSE;
+    accelerate_flag = false;
   if (skills_[0].time_remain) {
     skills_[0].time_remain -= 1;
   } else {
@@ -157,7 +157,7 @@ void ElementaryTank::Accelerate() {
     if (player) {
       auto &input_data = player->GetInputData();
       if (input_data.key_down[GLFW_KEY_Q]) {
-        accelerate_flag = TRUE;
+        accelerate_flag = true;
         accelerate_time = 0;
         skills_[0].time_remain = skills_[0].time_total;
         num_strong_bullets = 3;

--- a/src/battle_game/core/units/elementary_tank.cpp
+++ b/src/battle_game/core/units/elementary_tank.cpp
@@ -216,7 +216,6 @@ void ElementaryTank::Fire() {
               turret_rotation_, GetDamageScale(), velocity);
           num_strong_bullets -= 1;
         } else
-
           GenerateBullet<bullet::CannonBall>(
               position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
               turret_rotation_, GetDamageScale(), velocity);

--- a/src/battle_game/core/units/elementary_tank.h
+++ b/src/battle_game/core/units/elementary_tank.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "battle_game/core/unit.h"
+
+namespace battle_game::unit {
+class ElementaryTank : public Unit {
+ public:
+  ElementaryTank(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+
+ protected:
+  void TankMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+  void Accelerate();
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+
+  float turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+  bool accelerate_flag = FALSE;
+  int accelerate_time;
+  int num_strong_bullets = 0;
+};
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/elementary_tank.h
+++ b/src/battle_game/core/units/elementary_tank.h
@@ -14,13 +14,16 @@ class ElementaryTank : public Unit {
   void TurretRotate();
   void Fire();
   void Accelerate();
+  void RageShoot();
   [[nodiscard]] const char *UnitName() const override;
   [[nodiscard]] const char *Author() const override;
 
   float turret_rotation_{0.0f};
   uint32_t fire_count_down_{0};
   bool accelerate_flag = false;
+  bool rageshoot_flag = false;
   int accelerate_time;
+  int rageshoot_time;
   int num_strong_bullets = 0;
 };
 }  // namespace battle_game::unit

--- a/src/battle_game/core/units/elementary_tank.h
+++ b/src/battle_game/core/units/elementary_tank.h
@@ -19,7 +19,7 @@ class ElementaryTank : public Unit {
 
   float turret_rotation_{0.0f};
   uint32_t fire_count_down_{0};
-  bool accelerate_flag = FALSE;
+  bool accelerate_flag = false;
   int accelerate_time;
   int num_strong_bullets = 0;
 };

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -8,3 +8,4 @@
 #include "battle_game/core/units/three_body_man.h"
 #include "battle_game/core/units/tiny_tank.h"
 #include "battle_game/core/units/triple_shot_tank.h"
+#include "battle_game/core/units/elementary_tank.h"

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "battle_game/core/units/Whaooooo_tank.h"
 #include "battle_game/core/units/double_scatter_tank.h"
+#include "battle_game/core/units/elementary_tank.h"
 #include "battle_game/core/units/inferno_tank.h"
 #include "battle_game/core/units/missile_tank.h"
 #include "battle_game/core/units/square_tank.h"
@@ -8,4 +9,3 @@
 #include "battle_game/core/units/three_body_man.h"
 #include "battle_game/core/units/tiny_tank.h"
 #include "battle_game/core/units/triple_shot_tank.h"
-#include "battle_game/core/units/elementary_tank.h"


### PR DESCRIPTION
在子弹shuriken中加入了暴击机制，使用elementary tank时，使用rageshoot技能后子弹可以暴击。
由于子弹的接口不能更改，所以我还不大清楚怎么让所有的子弹都产生暴击效果，因为伤害判定是发生在每个人写的bullet里的。