### PR TITLE
[Debug] Fix issue #190

### DIFF
--- a/src/battle_game/core/game_core.h
+++ b/src/battle_game/core/game_core.h
@@ -185,6 +185,8 @@ class GameCore {
   glm::vec2 RandomInCircle();
 
  private:
+  std::queue<std::function<void()>> event_queue_;
+
   std::map<uint32_t, std::unique_ptr<Unit>> units_;
   uint32_t unit_index_{1};
   std::map<uint32_t, std::unique_ptr<Bullet>> bullets_;
@@ -199,8 +201,6 @@ class GameCore {
   uint32_t render_perspective_{
       0};  // This is a player id, defines which player is currently watching
            // the scene. 0 denote neutral.
-
-  std::queue<std::function<void()>> event_queue_;
 
   glm::vec2 camera_position_{0.0f};
   float camera_rotation_{0.0f};


### PR DESCRIPTION
This bug is due to the order of running the destructors. `event_queue_` will be destroyed before `bullets_`, and when the destructor in some bullet calls `PushEventGenerateParticle`, the segmentation fault will occur.

It will fix #190 if it is merged.

Reference:
In [Destructors - cppreference.com](https://en.cppreference.com/w/cpp/language/destructor#Destruction_sequence):
> ### Destruction sequence
> For both user-defined or implicitly-defined destructors, after executing the body of the destructor and destroying any automatic objects allocated within the body, the compiler calls the destructors for all non-static non-variant data members of the class, **in reverse order of declaration**, then it calls the destructors of all direct non-virtual base classes in [reverse order of construction](https://en.cppreference.com/w/cpp/language/initializer_list#Initialization_order) (which in turn call the destructors of their members and their base classes, etc), and then, if this object is of most-derived class, it calls the destructors of all virtual bases.