### PR TITLE
[New Obstacle] Bramble

### DIFF
--- a/src/battle_game/core/README.md
+++ b/src/battle_game/core/README.md
@@ -19,6 +19,7 @@ protected:
     glm::vec2 position_{0.0f};  // offset from the origin (0, 0)
     float rotation_{0.0f};      // angle in radians
     uint32_t id_{0};
+    ObjectType object_type_{untracked_object};
 };
 ```
 
@@ -36,6 +37,8 @@ protected:
   - position_ 表示对象相对于游戏内坐标原点的偏移量
   - glm::vec2 是 glm 数学运算库中表示单精度浮点二维向量的类型，这个数学库内包含了四维及以下向量、矩阵的类型定义和常用功能函数。
   - rotation_ 表示对象在场景内相比于默认朝向，逆时针旋转的角度
+- object_type_
+  - 表示对象的种类
 
 除成员变量外，所有对象都应包含两部分功能：
 
@@ -87,6 +90,8 @@ public:
   - 这些变量保存了生命条的设置，请通过set来修改
 - fadeout_health_
   - 保存生命条渐变的起始位置。（一般不需要修改）
+- unit_type_
+  - 表示单位的种类（bullet, obstacle, particle也有类似的变量）
 
 ### 成员函数
 
@@ -124,6 +129,8 @@ public:
 - RenderHelper
   - 这是一个虚函数
   - 仅在该单位所有者玩家的视角中，渲染该对象用于辅助的一些视觉效果（例如子弹射出的预计轨迹）
+- GetUnitType
+  - 获取该单位的种类（bullet, obstacle, particle也有类似的函数）
 - IsHit
   - 这是一个虚函数
   - 用于判断若一个事件发生于传入参数**世界空间**坐标 `position`，该事件是否会对当前单位产生影响

--- a/src/battle_game/core/bullet.cpp
+++ b/src/battle_game/core/bullet.cpp
@@ -12,6 +12,7 @@ Bullet::Bullet(GameCore *core,
       unit_id_(unit_id),
       player_id_(player_id),
       damage_scale_(damage_scale) {
+        object_type_ = bullet_;
 }
 
 Bullet::~Bullet() = default;

--- a/src/battle_game/core/bullet.h
+++ b/src/battle_game/core/bullet.h
@@ -4,6 +4,14 @@
 #include "cstdint"
 
 namespace battle_game {
+enum BulletType // use lowercase to avoid class name
+{
+  untracked_bullet,     
+  cannon_ball
+  // add your bullet here:
+  
+};
+
 class GameCore;
 class Bullet : public Object {
  public:
@@ -15,10 +23,14 @@ class Bullet : public Object {
          float rotation,
          float damage_scale);
   ~Bullet() override;
+  [[nodiscard]] BulletType GetBulletType() const {
+      return bullet_type_;
+  }
 
  protected:
   uint32_t unit_id_{};
   uint32_t player_id_{};
   float damage_scale_{1.0f};
+  BulletType bullet_type_{untracked_bullet};
 };
 }  // namespace battle_game

--- a/src/battle_game/core/bullets/cannon_ball.cpp
+++ b/src/battle_game/core/bullets/cannon_ball.cpp
@@ -28,7 +28,11 @@ void CannonBall::Update() {
   position_ += velocity_ * kSecondPerTick;
   bool should_die = false;
   if (game_core_->IsBlockedByObstacles(position_)) {
-    should_die = true;
+    if (!(game_core_->IsOutOfRange(position_)) &&
+    game_core_->GetBlockedObstacle(position_)->GetObstacleType() == bramble)
+      should_die = false;
+    else
+      should_die = true;
   }
 
   auto &units = game_core_->GetUnits();

--- a/src/battle_game/core/bullets/cannon_ball.cpp
+++ b/src/battle_game/core/bullets/cannon_ball.cpp
@@ -14,6 +14,7 @@ CannonBall::CannonBall(GameCore *core,
                        glm::vec2 velocity)
     : Bullet(core, id, unit_id, player_id, position, rotation, damage_scale),
       velocity_(velocity) {
+        bullet_type_ = cannon_ball;
 }
 
 void CannonBall::Render() {

--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -276,6 +276,7 @@ int GameCore::RandomInt(int low_bound, int high_bound) {
 
 void GameCore::SetScene() {
   AddObstacle<obstacle::Block>(glm::vec2{-3.0f, 4.0f});
+  AddObstacle<obstacle::Bramble>(glm::vec2{-3.0f, -4.0f});
   AddObstacle<obstacle::ReboundingBlock>(glm::vec2{-10.0f, -10.0f},
                                          0.78539816339744830961566084581988f);
   AddObstacle<obstacle::ReboundingBlock>(glm::vec2{10.0f, -10.0f},

--- a/src/battle_game/core/object.h
+++ b/src/battle_game/core/object.h
@@ -62,6 +62,15 @@ struct Skill {
         function(function){};
 };
 
+enum ObjectType // add an underline to avoid the namespace name
+{ 
+  untracked_object,
+  unit_,
+  bullet_,
+  obstacle_,
+  particle_
+};
+
 class Object {
  public:
   Object(GameCore *game_core,
@@ -83,6 +92,9 @@ class Object {
   [[nodiscard]] uint32_t GetId() const {
     return id_;
   }
+  [[nodiscard]] ObjectType GetObjectType() const {
+    return object_type_;
+  }
 
   virtual void Render() = 0;
   virtual void Update() = 0;
@@ -92,5 +104,6 @@ class Object {
   glm::vec2 position_{0.0f};  // offset from the origin (0, 0)
   float rotation_{0.0f};      // angle in radians
   uint32_t id_{0};
+  ObjectType object_type_{untracked_object};
 };
 }  // namespace battle_game

--- a/src/battle_game/core/obstacle.cpp
+++ b/src/battle_game/core/obstacle.cpp
@@ -7,6 +7,7 @@ Obstacle::Obstacle(GameCore *game_core,
                    glm::vec2 position,
                    float rotation)
     : Object(game_core, id, position, rotation) {
+        object_type_ = obstacle_;
 }
 
 void Obstacle::Update() {

--- a/src/battle_game/core/obstacle.h
+++ b/src/battle_game/core/obstacle.h
@@ -3,6 +3,14 @@
 #include "glm/glm.hpp"
 
 namespace battle_game {
+enum ObstacleType // use lowercase to avoid class name
+{
+  untracked_obstacle,
+  block
+  // add your obstacle here:
+
+};
+
 class Obstacle : public Object {
  public:
   Obstacle(GameCore *game_core,
@@ -16,7 +24,11 @@ class Obstacle : public Object {
                                                            glm::vec2 terminus) {
     return std::make_pair(glm::vec2(0, 0), glm::vec2(0, 0));
   }
+  [[nodiscard]] ObstacleType GetObstacleType() const {
+    return obstacle_type_;
+  }
 
  protected:
+  ObstacleType obstacle_type_{untracked_obstacle};
 };
 }  // namespace battle_game

--- a/src/battle_game/core/obstacle.h
+++ b/src/battle_game/core/obstacle.h
@@ -6,9 +6,9 @@ namespace battle_game {
 enum ObstacleType // use lowercase to avoid class name
 {
   untracked_obstacle,
-  block
+  block,
   // add your obstacle here:
-
+  bramble
 };
 
 class Obstacle : public Object {

--- a/src/battle_game/core/obstacles/block.cpp
+++ b/src/battle_game/core/obstacles/block.cpp
@@ -8,6 +8,7 @@ Block::Block(GameCore *game_core,
              float rotation,
              glm::vec2 scale)
     : Obstacle(game_core, id, position, rotation) {
+      obstacle_type_ = block;
 }
 
 bool Block::IsBlocked(glm::vec2 p) const {

--- a/src/battle_game/core/obstacles/bramble.cpp
+++ b/src/battle_game/core/obstacles/bramble.cpp
@@ -1,0 +1,26 @@
+#include "battle_game/core/obstacles/bramble.h"
+
+namespace battle_game::obstacle {
+
+Bramble::Bramble(GameCore *game_core,
+             uint32_t id,
+             glm::vec2 position,
+             float rotation,
+             glm::vec2 scale)
+    : Obstacle(game_core, id, position, rotation) {
+      obstacle_type_ = bramble;
+}
+
+bool Bramble::IsBlocked(glm::vec2 p) const {
+  p = WorldToLocal(p);
+  return p.x <= scale_.x && p.x >= -scale_.x && p.y <= scale_.y &&
+         p.y >= -scale_.y;
+}
+
+void Bramble::Render() {
+  battle_game::SetColor(glm::vec4{1.0f, 0.0f, 0.0f, 1.0f});
+  battle_game::SetTexture(0);
+  battle_game::SetTransformation(position_, rotation_, scale_);
+  battle_game::DrawModel(0);
+}
+}  // namespace battle_game::obstacle

--- a/src/battle_game/core/obstacles/bramble.h
+++ b/src/battle_game/core/obstacles/bramble.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "battle_game/core/obstacle.h"
+
+namespace battle_game::obstacle {
+class Bramble : public Obstacle {
+ public:
+  Bramble(GameCore *game_core,
+        uint32_t id,
+        glm::vec2 position,
+        float rotation = 0.0f,
+        glm::vec2 scale = glm::vec2{1.0f, 1.0f});
+
+ private:
+  [[nodiscard]] bool IsBlocked(glm::vec2 p) const override;
+  void Render() override;
+  glm::vec2 scale_{1.0f};
+};
+}  // namespace battle_game::obstacle

--- a/src/battle_game/core/obstacles/obstacles.h
+++ b/src/battle_game/core/obstacles/obstacles.h
@@ -2,3 +2,4 @@
 #include "battle_game/core/obstacles/block.h"
 #include "battle_game/core/obstacles/rebounding_block.h"
 #include "battle_game/core/obstacles/safety_declaration.h"
+#include "battle_game/core/obstacles/bramble.h"

--- a/src/battle_game/core/particle.cpp
+++ b/src/battle_game/core/particle.cpp
@@ -6,5 +6,6 @@ Particle::Particle(GameCore *game_core,
                    glm::vec2 position,
                    float rotation)
     : Object(game_core, id, position, rotation) {
+        object_type_ = particle_;
 }
 }  // namespace battle_game

--- a/src/battle_game/core/particle.h
+++ b/src/battle_game/core/particle.h
@@ -2,13 +2,25 @@
 #include "battle_game/core/object.h"
 
 namespace battle_game {
+enum ParticleType // use lowercase to avoid class name
+{
+    untracked_particle,
+    smoke
+    // add your particle here:
+    
+};
+
 class Particle : public Object {
  public:
   Particle(GameCore *game_core,
            uint32_t id,
            glm::vec2 position,
            float rotation = 0.0f);
-
+  [[nodiscard]] ParticleType GetParticleType() const {
+    return particle_type_;
+  }
+ protected:
+    ParticleType particle_type_{untracked_particle};
  private:
 };
 }  // namespace battle_game

--- a/src/battle_game/core/particles/smoke.cpp
+++ b/src/battle_game/core/particles/smoke.cpp
@@ -16,6 +16,7 @@ Smoke::Smoke(GameCore *game_core,
       size_(size),
       color_(color),
       decay_scale_(decay_scale) {
+        particle_type_ = smoke;
 }
 
 void Smoke::Render() {

--- a/src/battle_game/core/unit.cpp
+++ b/src/battle_game/core/unit.cpp
@@ -25,6 +25,7 @@ Unit::Unit(GameCore *game_core, uint32_t id, uint32_t player_id)
          {{0.5f, -0.08f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}}},
         {0, 1, 2, 1, 2, 3});
   }
+  object_type_ = unit_;
 }
 
 void Unit::SetPosition(glm::vec2 position) {

--- a/src/battle_game/core/unit.h
+++ b/src/battle_game/core/unit.h
@@ -4,6 +4,14 @@
 
 namespace battle_game {
 
+enum UnitType // use lowercase to avoid class name
+{
+  untracked_unit,
+  tiny_tank
+  // add your unit here:
+
+};
+
 class Bullet;
 
 class Unit : public Object {
@@ -83,6 +91,9 @@ class Unit : public Object {
   const std::vector<Skill> &GetSkills() const {
     return skills_;
   }
+  [[nodiscard]] UnitType GetUnitType() const {
+    return unit_type_;
+  }
 
  protected:
   uint32_t player_id_{};
@@ -94,6 +105,7 @@ class Unit : public Object {
   glm::vec4 front_lifebar_color_{};
   glm::vec4 background_lifebar_color_{};
   glm::vec4 fadeout_lifebar_color_{};
+  UnitType unit_type_{untracked_unit};
 
  private:
   float fadeout_health_;

--- a/src/battle_game/core/units/tiny_tank.cpp
+++ b/src/battle_game/core/units/tiny_tank.cpp
@@ -68,6 +68,7 @@ Tank::Tank(GameCore *game_core, uint32_t id, uint32_t player_id)
           mgr->RegisterModel(turret_vertices, turret_indices);
     }
   }
+  unit_type_ = tiny_tank;
 }
 
 void Tank::Render() {

--- a/src/battle_game/core/units/tiny_tank.cpp
+++ b/src/battle_game/core/units/tiny_tank.cpp
@@ -106,6 +106,13 @@ void Tank::TankMove(float move_speed, float rotate_angular_speed) {
     if (!game_core_->IsBlockedByObstacles(new_position)) {
       game_core_->PushEventMoveUnit(id_, new_position);
     }
+    else {
+      if (!(game_core_->IsOutOfRange(new_position)) && game_core_
+      ->GetBlockedObstacle(new_position)->GetObstacleType() == bramble) {
+        game_core_->PushEventMoveUnit(id_, new_position);
+        game_core_->PushEventDealDamage(id_, id_, 0.08f);
+      }
+    }
     float rotation_offset = 0.0f;
     if (input_data.key_down[GLFW_KEY_A]) {
       rotation_offset += 1.0f;


### PR DESCRIPTION
在 #198 的基础上实现了新障碍物：Bramble。部分解决了issue #194 
Bramble使得子弹可以穿过去，不会阻挡坦克，但是坦克站在上面时约每秒掉5滴血。
为了避免修改过多代码，仅实现了cannon_ball的穿透和tiny_tank的掉血，由于大多数unit都继承了tiny_tank的移动，因此能实现大多数坦克的掉血。

实现方法与 #203 类似。

附上效果图：
<img width="651" alt="c315446d937c94c2ea5b90e1bc4d316" src="https://user-images.githubusercontent.com/113412883/211580876-e6a4af57-1fbb-4654-9807-44a01d40dfcc.png">
