### PR TITLE
Adding new unit called RandomAttackingTank --closes issue #256

### DIFF
--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -44,6 +44,7 @@ void GameCore::Update() {
     }
     particle.second->Update();
   }
+  SceneUpdate();
   ProcessEventQueue();
 }
 
@@ -101,6 +102,21 @@ void GameCore::Render() {
     if (observing_unit) {
       observing_unit->RenderHelper();
     }
+  }
+}
+/*
+ * This function is used to update third-party-units. Some units are not 
+ * operated by players nor future opponents, but are built-in moving units, 
+ * which can also be considered as a part of the scene. 
+ * Thus this function is written to implement the generation or other utilities.
+ * */
+void GameCore::SceneUpdate(){
+  if (generating_time_count_down_) {
+    generating_time_count_down_--;
+  } else {
+    AddUnit<unit::RandomAttackingTank>(2);
+    generating_time_count_down_ = 10 * kTickPerSecond; 
+    // generating one RandomAttackingTank per 10 second
   }
 }
 

--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -105,17 +105,17 @@ void GameCore::Render() {
   }
 }
 /*
- * This function is used to update third-party-units. Some units are not 
- * operated by players nor future opponents, but are built-in moving units, 
- * which can also be considered as a part of the scene. 
+ * This function is used to update third-party-units. Some units are not
+ * operated by players nor future opponents, but are built-in moving units,
+ * which can also be considered as a part of the scene.
  * Thus this function is written to implement the generation or other utilities.
  * */
-void GameCore::SceneUpdate(){
+void GameCore::SceneUpdate() {
   if (generating_time_count_down_) {
     generating_time_count_down_--;
   } else {
     AddUnit<unit::RandomAttackingTank>(2);
-    generating_time_count_down_ = 10 * kTickPerSecond; 
+    generating_time_count_down_ = 10 * kTickPerSecond;
     // generating one RandomAttackingTank per 10 second
   }
 }

--- a/src/battle_game/core/game_core.h
+++ b/src/battle_game/core/game_core.h
@@ -38,6 +38,7 @@ class GameCore {
 
   void Update();
   void Render();
+  void SceneUpdate();
 
   template <class UnitType, class... Args>
   uint32_t AddUnit(uint32_t player_id, Args... args) {
@@ -216,6 +217,7 @@ class GameCore {
       primary_unit_allocation_functions_;
   std::vector<std::string> selectable_unit_list_;
   std::vector<bool> selectable_unit_list_skill_;
+  uint32_t generating_time_count_down_{300};
 };
 
 template <class BulletType, class... Args>

--- a/src/battle_game/core/units/random_attacking_tank.cpp
+++ b/src/battle_game/core/units/random_attacking_tank.cpp
@@ -1,0 +1,199 @@
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+#include <iostream>
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+RandomAttackingTank::RandomAttackingTank(GameCore *game_core, uint32_t id, uint32_t player_id)
+    : Unit(game_core, id, player_id) {
+  if (!~tank_body_model_index) {
+    auto mgr = AssetsManager::GetInstance();
+    {
+      /* Tank Body */
+      std::vector<ObjectVertex> body_vertices;
+      std::vector<uint32_t> body_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        body_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
+                                 {0.0f, 0.0f},
+                                 {1.0f, 1.0f, 1.0f, 1.0f}});
+        body_indices.push_back(i);
+        body_indices.push_back((i + 1) % precision);
+        body_indices.push_back(precision);
+      }
+      tank_body_model_index = mgr->RegisterModel(body_vertices, body_indices);
+    }
+
+    {
+      /* Tank Turret */
+      std::vector<ObjectVertex> turret_vertices;
+      std::vector<uint32_t> turret_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        turret_vertices.push_back({{sin_theta * 0.25f, cos_theta * 0.25f},
+                                   {0.0f, 0.0f},
+                                   {0.7f, 0.7f, 0.7f, 1.0f}});
+        turret_indices.push_back(i);
+        turret_indices.push_back((i + 1) % precision);
+        turret_indices.push_back(precision);
+      }
+      turret_vertices.push_back(
+          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.05f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.05f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.05f, 0.6f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.05f, 0.6f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_indices.push_back(precision + 1 + 0);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 3);
+      tank_turret_model_index =
+          mgr->RegisterModel(turret_vertices, turret_indices);
+    }
+    turret_rotation_ = glm::radians(game_core_->RandomFloat() * 360.0f);
+    rotation_ = glm::radians(game_core_->RandomFloat() * 360.0f);
+  }
+}
+
+void RandomAttackingTank::Render() {
+  battle_game::SetTransformation(position_, rotation_);
+  battle_game::SetTexture(0);
+  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
+  battle_game::DrawModel(tank_body_model_index);
+  battle_game::SetRotation(turret_rotation_);
+  battle_game::DrawModel(tank_turret_model_index);
+}
+
+void RandomAttackingTank::Update() {
+  TankMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Fire();
+}
+
+void RandomAttackingTank::TankMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    glm::vec2 offset{0.0f};
+    offset.y += 0.5f + game_core_->RandomFloat() * 0.5;
+    float speed = move_speed * GetSpeedScale();
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    float rotation_offset = 0.0f;
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    } 
+    else {
+      auto blocked_obstacle = game_core_->GetBlockedObstacle(new_position);
+      if (blocked_obstacle != nullptr){
+        auto normal = blocked_obstacle->GetSurfaceNormal(position_, new_position);
+        rotation_offset = - 2 * rotation_ 
+          + 2 * std::atan2(normal.second.y, normal.second.x);
+      }
+    }
+    if (move_rotation_count_down_) {
+      move_rotation_count_down_--;
+    } 
+    else {
+      rotation_offset += 
+        glm::radians(game_core_->RandomFloat() * 360.0f);
+      rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+      move_rotation_count_down_ = kTickPerSecond/3;
+    }
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+void RandomAttackingTank::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    bool is_anti_clockwise = change_of_turret_rotation_ > 0;
+    if (change_of_turret_rotation_ > glm::radians(5.0f)) {
+      turret_rotation_count_down_ = 15;
+    } else if (change_of_turret_rotation_ < glm::radians(-5.0f) ) {
+      turret_rotation_count_down_ = 15;
+    }
+    if (turret_rotation_count_down_) {
+      turret_rotation_count_down_--;
+      if (is_anti_clockwise){
+        change_of_turret_rotation_ -= glm::radians(0.4f);
+      }
+      else {
+        change_of_turret_rotation_ += glm::radians(0.4f);
+      }
+    } 
+    else {
+      change_of_turret_rotation_ += 
+        glm::radians((game_core_->RandomFloat() - 0.5f) * 1.2f);
+    }
+    turret_rotation_ += change_of_turret_rotation_;
+  }
+}
+
+void RandomAttackingTank::Fire() {
+  if (fire_count_down_) {
+    fire_count_down_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      {
+        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+        GenerateBullet<bullet::CannonBall>(
+            position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+            turret_rotation_, GetDamageScale(), velocity);
+        fire_count_down_ = 0.8*kTickPerSecond;  // Fire interval 0.8 second.
+      }
+    }
+  }
+}
+
+bool RandomAttackingTank::IsHit(glm::vec2 position) const {
+  position = WorldToLocal(position);
+  return pow(position.x, 2) + pow(position.y, 2) <= 0.25f;
+}
+
+float RandomAttackingTank::GetSpeedScale() const {
+  return 0.8f;
+}
+
+float RandomAttackingTank::GetDamageScale() const {
+  return 0.3f;
+}
+
+float RandomAttackingTank::BasicMaxHealth() const {
+  return 30.0f;
+}
+
+const char *RandomAttackingTank::UnitName() const {
+  return "Random Attacking Tank";
+}
+
+const char *RandomAttackingTank::Author() const {
+  return "Chen Rui Qin Fang";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/random_attacking_tank.cpp
+++ b/src/battle_game/core/units/random_attacking_tank.cpp
@@ -1,7 +1,6 @@
 #include "battle_game/core/bullets/bullets.h"
 #include "battle_game/core/game_core.h"
 #include "battle_game/graphics/graphics.h"
-#include <iostream>
 
 namespace battle_game::unit {
 
@@ -106,23 +105,23 @@ void RandomAttackingTank::TankMove(float move_speed, float rotate_angular_speed)
     float rotation_offset = 0.0f;
     if (!game_core_->IsBlockedByObstacles(new_position)) {
       game_core_->PushEventMoveUnit(id_, new_position);
-    } 
+    }
     else {
       auto blocked_obstacle = game_core_->GetBlockedObstacle(new_position);
       if (blocked_obstacle != nullptr){
         auto normal = blocked_obstacle->GetSurfaceNormal(position_, new_position);
-        rotation_offset = - 2 * rotation_ 
+        rotation_offset = -2 * rotation_
           + 2 * std::atan2(normal.second.y, normal.second.x);
       }
     }
     if (move_rotation_count_down_) {
       move_rotation_count_down_--;
-    } 
+    }
     else {
-      rotation_offset += 
+      rotation_offset +=
         glm::radians(game_core_->RandomFloat() * 360.0f);
       rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
-      move_rotation_count_down_ = kTickPerSecond/3;
+      move_rotation_count_down_ = kTickPerSecond / 3;
     }
     game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
   }
@@ -134,20 +133,20 @@ void RandomAttackingTank::TurretRotate() {
     bool is_anti_clockwise = change_of_turret_rotation_ > 0;
     if (change_of_turret_rotation_ > glm::radians(5.0f)) {
       turret_rotation_count_down_ = 15;
-    } else if (change_of_turret_rotation_ < glm::radians(-5.0f) ) {
+    } else if (change_of_turret_rotation_ < glm::radians(-5.0f)) {
       turret_rotation_count_down_ = 15;
     }
     if (turret_rotation_count_down_) {
       turret_rotation_count_down_--;
-      if (is_anti_clockwise){
+      if (is_anti_clockwise) {
         change_of_turret_rotation_ -= glm::radians(0.4f);
       }
       else {
         change_of_turret_rotation_ += glm::radians(0.4f);
       }
-    } 
+    }
     else {
-      change_of_turret_rotation_ += 
+      change_of_turret_rotation_ +=
         glm::radians((game_core_->RandomFloat() - 0.5f) * 1.2f);
     }
     turret_rotation_ += change_of_turret_rotation_;
@@ -166,7 +165,7 @@ void RandomAttackingTank::Fire() {
         GenerateBullet<bullet::CannonBall>(
             position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
             turret_rotation_, GetDamageScale(), velocity);
-        fire_count_down_ = 0.8*kTickPerSecond;  // Fire interval 0.8 second.
+        fire_count_down_ = 0.8 * kTickPerSecond;  // Fire interval 0.8 second.
       }
     }
   }

--- a/src/battle_game/core/units/random_attacking_tank.h
+++ b/src/battle_game/core/units/random_attacking_tank.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "battle_game/core/unit.h"
+
+namespace battle_game::unit {
+class RandomAttackingTank : public Unit {
+ public:
+  RandomAttackingTank(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+  
+  [[nodiscard]] float GetDamageScale() const override;
+  [[nodiscard]] float GetSpeedScale() const override;
+  [[nodiscard]] float BasicMaxHealth() const override;
+
+ protected:
+  void TankMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+
+  float turret_rotation_{0.0f};
+  float change_of_turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+  uint32_t move_rotation_count_down_{0};
+  uint32_t turret_rotation_count_down_{0};
+};
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -17,3 +17,4 @@
 #include "battle_game/core/units/tiny_tank.h"
 #include "battle_game/core/units/triple_shot_tank.h"
 #include "battle_game/core/units/zibeng_dog.h"
+#include "battle_game/core/units/random_attacking_tank.h"


### PR DESCRIPTION
实现#256 [Utility] Npc tanks 中的小坦克。
小坦克的移动速度、生命值和子弹伤害相较tinytank降低，尺度变小，随机地运动、发射。攻击不分敌我，小坦克间亦可以相互攻击。
每过10秒，地图中央自动生成一个小坦克。这一特性通过在GameCore::Update中新增一个SceneUpdate函数实现。
效果如图：
![BTYIFU$UV7C YT2D_4P$BPT](https://user-images.githubusercontent.com/113405897/212112089-486d28c2-09a8-4b3b-91f4-edf3d0c7f317.png)
![27~%MVKSKAR$_KB` ~`BX2L](https://user-images.githubusercontent.com/113405897/212124216-3b56aef3-ddce-433e-8ece-9c080fe35d94.png)
