### PR TITLE
[Debug] about Skill GUI (want to be merged)

### DIFF
--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -30,11 +30,9 @@ void GameCore::GeneratePrimaryUnitList() {
    * TODO: Add Your Unit Here!
    * */
   ADD_SELECTABLE_UNIT(unit::InfernoTank);
-  ADD_SELECTABLE_UNIT(unit::RoundUFO);
   ADD_SELECTABLE_UNIT(unit::Tank);
   ADD_SELECTABLE_UNIT(unit::DoubleScatterTank);
   ADD_SELECTABLE_UNIT(unit::ThreeBodyMan);
-  ADD_SELECTABLE_UNIT(unit::InfernoTank);
   ADD_SELECTABLE_UNIT(unit::LMTank);
   ADD_SELECTABLE_UNIT(unit::MissileTank);
   ADD_SELECTABLE_UNIT(unit::TripleShotTank);

--- a/src/battle_game/core/units/inferno_tank.h
+++ b/src/battle_game/core/units/inferno_tank.h
@@ -22,7 +22,7 @@ class InfernoTank : public Tank {
 
   // float turret_rotation_{0.0f};
   uint32_t fire_count_down_{0};
-  uint32_t shoot_count_down_{0};
+  uint32_t shoot_count_down_{240};
   uint32_t hidden_count_down_{600};
   uint32_t block_count_down_{600};
   uint32_t isHidden{0};


### PR DESCRIPTION
在单位选择列表中inferno_tank和round_UFO出现了两次，导致skill界面出现了混乱，已修复。
顺便解决了inferno_tank开幕雷击的不佳体验