### PR TITLE
Magic Tank

### DIFF
--- a/src/battle_game/core/bullets/bullets.h
+++ b/src/battle_game/core/bullets/bullets.h
@@ -2,6 +2,7 @@
 #include "battle_game/core/bullets/cannon_ball.h"
 #include "battle_game/core/bullets/coin.h"
 #include "battle_game/core/bullets/crit_bullet.h"
+#include "battle_game/core/bullets/deathball.h"
 #include "battle_game/core/bullets/electric_ball.h"
 #include "battle_game/core/bullets/energy_beam.h"
 #include "battle_game/core/bullets/mine.h"

--- a/src/battle_game/core/bullets/deathball.cpp
+++ b/src/battle_game/core/bullets/deathball.cpp
@@ -1,4 +1,4 @@
-#include "battle_game/core/bullets/Deathball.h"
+#include "battle_game/core/bullets/deathball.h"
 
 #include "battle_game/core/game_core.h"
 #include "battle_game/core/particles/particles.h"

--- a/src/battle_game/core/bullets/deathball.cpp
+++ b/src/battle_game/core/bullets/deathball.cpp
@@ -1,0 +1,53 @@
+#include "battle_game/core/bullets/Deathball.h"
+
+#include "battle_game/core/game_core.h"
+#include "battle_game/core/particles/particles.h"
+
+namespace battle_game::bullet {
+Deathball::Deathball(GameCore *core,
+                     uint32_t id,
+                     uint32_t unit_id,
+                     uint32_t player_id,
+                     glm::vec2 position,
+                     float rotation,
+                     float damage_scale,
+                     glm::vec2 velocity)
+    : Bullet(core, id, unit_id, player_id, position, rotation, damage_scale),
+      velocity_(velocity) {
+}
+
+void Deathball::Render() {
+  SetTransformation(position_, rotation_, glm::vec2{0.1f});
+  SetColor(game_core_->GetPlayerColor(player_id_));
+  SetTexture("../../textures/particle3.png");
+  DrawModel(0);
+}
+
+void Deathball::Update() {
+  position_ += velocity_ * kSecondPerTick;
+  bool should_die = false;
+  if (game_core_->IsBlockedByObstacles(position_)) {
+    should_die = true;
+  }
+
+  auto &units = game_core_->GetUnits();
+  for (auto &unit : units) {
+    if (unit.second->IsHit(position_)) {
+      game_core_->PushEventKillUnit(unit.first, id_);
+      should_die = true;
+    }
+  }
+
+  if (should_die) {
+    game_core_->PushEventRemoveBullet(id_);
+  }
+}
+
+Deathball::~Deathball() {
+  for (int i = 0; i < 5; i++) {
+    game_core_->PushEventGenerateParticle<particle::Smoke>(
+        position_, rotation_, game_core_->RandomInCircle() * 2.0f, 0.2f,
+        glm::vec4{0.0f, 0.0f, 0.0f, 1.0f}, 3.0f);
+  }
+}
+}  // namespace battle_game::bullet

--- a/src/battle_game/core/bullets/deathball.h
+++ b/src/battle_game/core/bullets/deathball.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "battle_game/core/bullet.h"
+
+namespace battle_game::bullet {
+class Deathball : public Bullet {
+ public:
+  Deathball(GameCore *core,
+            uint32_t id,
+            uint32_t unit_id,
+            uint32_t player_id,
+            glm::vec2 position,
+            float rotation,
+            float damage_scale,
+            glm::vec2 velocity);
+  ~Deathball() override;
+  void Render() override;
+  void Update() override;
+
+ private:
+  glm::vec2 velocity_{};
+};
+}  // namespace battle_game::bullet

--- a/src/battle_game/core/units/magic_tank.cpp
+++ b/src/battle_game/core/units/magic_tank.cpp
@@ -1,0 +1,185 @@
+#include "magic_tank.h"
+
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+MagicTank::MagicTank(GameCore *game_core, uint32_t id, uint32_t player_id)
+    : Tank(game_core, id, player_id) {
+  {
+    /* Tank skill protect*/
+    Skill temp;
+    temp.name = "Protect";
+    temp.description = "Prevent any possible damage";
+    temp.time_remain = 0;
+    temp.time_total = 60;
+    temp.type = E;
+    temp.function = SKILL_ADD_FUNCTION(MagicTank::Protect);
+    skills_.push_back(temp);
+    Skill temp2;
+    temp2.name = "Death";
+    temp2.description = "Shoot deathball to enemies";
+    temp2.time_remain = 0;
+    temp2.time_total = 240;
+    temp2.type = Q;
+    temp2.function = SKILL_ADD_FUNCTION(MagicTank::Death);
+    skills_.push_back(temp2);
+  }
+}
+
+void MagicTank::Render() {
+  Tank::Render();
+}
+
+void MagicTank::Update() {
+  TankMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Fire();
+  Protect();
+  Death();
+  magic();
+}
+
+void MagicTank::TankMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    glm::vec2 offset{0.0f};
+    if (input_data.key_down[GLFW_KEY_W]) {
+      offset.y += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_S]) {
+      offset.y -= 1.0f;
+    }
+    float speed = move_speed * GetSpeedScale();
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    }
+    float rotation_offset = 0.0f;
+    if (input_data.key_down[GLFW_KEY_A]) {
+      rotation_offset += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_D]) {
+      rotation_offset -= 1.0f;
+    }
+    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+void MagicTank::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    auto diff = input_data.mouse_cursor_position - position_;
+    if (glm::length(diff) < 1e-4) {
+      turret_rotation_ = rotation_;
+    } else {
+      turret_rotation_ = std::atan2(diff.y, diff.x) - glm::radians(90.0f);
+    }
+  }
+}
+
+void MagicTank::Fire() {
+  if (fire_count_down_) {
+    fire_count_down_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+        GenerateBullet<bullet::CannonBall>(
+            position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+            turret_rotation_, GetDamageScale(), velocity);
+        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+      }
+    }
+  }
+}
+
+void MagicTank::ProtectClick() {
+  protecteed = true;
+  protectskill_countdown_ = 20 * kTickPerSecond;
+}
+
+void MagicTank::DeathClick() {
+  deathcool_countdown_ = 240;
+  health_ /= 2;  // Death should have some side effect
+  auto velocity = Rotate(glm::vec2{0.0f, 10.0f}, turret_rotation_);
+  GenerateBullet<bullet::Deathball>(
+      position_ + Rotate({0.0f, 1.2f}, turret_rotation_), turret_rotation_,
+      GetDamageScale(), velocity);
+}
+
+void MagicTank::magic() {
+  if (protecteed) {
+    if (protectskill_countdown_) {
+      protectskill_countdown_--;
+      if (protectskill_countdown_ == 0) {
+        protecteed = false;
+        protectcool_countdown = 60 * kTickPerSecond;
+      }
+    }
+  }
+}
+
+void MagicTank::Protect() {
+  skills_[0].time_remain = protectcool_countdown;
+  if (protectcool_countdown) {
+    protectcool_countdown--;
+  } else if (protecteed == false) {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.key_down[GLFW_KEY_E]) {
+        ProtectClick();
+      }
+    }
+  }
+}
+
+void MagicTank::Death() {
+  skills_[1].time_remain = deathcool_countdown_;
+  if (deathcool_countdown_) {
+    deathcool_countdown_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.key_down[GLFW_KEY_Q]) {
+        DeathClick();
+      }
+    }
+  }
+}
+
+bool MagicTank::IsHit(glm::vec2 position) const {
+  if (protecteed == true)
+    return false;  // Under Protected
+  position = WorldToLocal(position);
+  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
+         position.y < 1.0f && position.x + position.y < 1.6f &&
+         position.y - position.x < 1.6f;
+}
+
+const char *MagicTank::UnitName() const {
+  return "Magic Tank";
+}
+
+const char *MagicTank::Author() const {
+  return "PorridgeSailing";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/magic_tank.cpp
+++ b/src/battle_game/core/units/magic_tank.cpp
@@ -124,22 +124,22 @@ void MagicTank::DeathClick() {
       GetDamageScale(), velocity);
 }
 
-void MagicTank::magic() {
+void MagicTank::Magic() {
   if (protecteed) {
     if (protectskill_countdown_) {
       protectskill_countdown_--;
       if (protectskill_countdown_ == 0) {
         protecteed = false;
-        protectcool_countdown = 60 * kTickPerSecond;
+        protectcool_countdown_ = 60 * kTickPerSecond;
       }
     }
   }
 }
 
 void MagicTank::Protect() {
-  skills_[0].time_remain = protectcool_countdown;
-  if (protectcool_countdown) {
-    protectcool_countdown--;
+  skills_[0].time_remain = protectcool_countdown_;
+  if (protectcool_countdown_) {
+    protectcool_countdown_--;
   } else if (protecteed == false) {
     auto player = game_core_->GetPlayer(player_id_);
     if (player) {

--- a/src/battle_game/core/units/magic_tank.cpp
+++ b/src/battle_game/core/units/magic_tank.cpp
@@ -44,7 +44,7 @@ void MagicTank::Update() {
   Fire();
   Protect();
   Death();
-  magic();
+  Magic();
 }
 
 void MagicTank::TankMove(float move_speed, float rotate_angular_speed) {

--- a/src/battle_game/core/units/magic_tank.h
+++ b/src/battle_game/core/units/magic_tank.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "battle_game/core/unit.h"
+#include "battle_game/core/units/tiny_tank.h"
+namespace battle_game::unit {
+class MagicTank : public Tank {
+ public:
+  MagicTank(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  uint32_t protectskill_countdown_ = {0};
+  uint32_t protectcool_countdown = 60;
+  uint32_t deathcool_countdown_ = 0;
+  bool protecteed = false;
+  void Protect();
+  void Death();
+  void ProtectClick();
+  void DeathClick();
+  void magic();
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+
+ protected:
+  void TankMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+
+  float turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+  uint32_t mine_count_down_{0};
+};
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/magic_tank.h
+++ b/src/battle_game/core/units/magic_tank.h
@@ -7,16 +7,17 @@ class MagicTank : public Tank {
   MagicTank(GameCore *game_core, uint32_t id, uint32_t player_id);
   void Render() override;
   void Update() override;
-  void Protect();
-  void Death();
-  void ProtectClick();
-  void DeathClick();
-  void Magic();
+
   [[nodiscard]] bool IsHit(glm::vec2 position) const override;
 
  protected:
   void TankMove(float move_speed, float rotate_angular_speed);
   void TurretRotate();
+  void Protect();
+  void Death();
+  void ProtectClick();
+  void DeathClick();
+  void Magic();
   void Fire();
 
   [[nodiscard]] const char *UnitName() const override;

--- a/src/battle_game/core/units/magic_tank.h
+++ b/src/battle_game/core/units/magic_tank.h
@@ -7,15 +7,11 @@ class MagicTank : public Tank {
   MagicTank(GameCore *game_core, uint32_t id, uint32_t player_id);
   void Render() override;
   void Update() override;
-  uint32_t protectskill_countdown_ = {0};
-  uint32_t protectcool_countdown = 60;
-  uint32_t deathcool_countdown_ = 0;
-  bool protecteed = false;
   void Protect();
   void Death();
   void ProtectClick();
   void DeathClick();
-  void magic();
+  void Magic();
   [[nodiscard]] bool IsHit(glm::vec2 position) const override;
 
  protected:
@@ -27,7 +23,11 @@ class MagicTank : public Tank {
   [[nodiscard]] const char *Author() const override;
 
   float turret_rotation_{0.0f};
-  uint32_t fire_count_down_{0};
-  uint32_t mine_count_down_{0};
+  bool protecteed = false;
+  uint32_t protectskill_countdown_ = {0};
+  uint32_t protectcool_countdown_ = 60;
+  uint32_t deathcool_countdown_ = 0;
+  uint32_t fire_count_down_ = 0;
+  uint32_t mine_count_down_ = 0;
 };
 }  // namespace battle_game::unit

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -6,6 +6,7 @@
 #include "battle_game/core/units/double_scatter_tank.h"
 #include "battle_game/core/units/inferno_tank.h"
 #include "battle_game/core/units/lm_tank.h"
+#include "battle_game/core/units/magic_tank.h"
 #include "battle_game/core/units/mine_sample_tank.h"
 #include "battle_game/core/units/missile_tank.h"
 #include "battle_game/core/units/rage_tank_yangyr.h"


### PR DESCRIPTION
Magic Tank is tiny_tank with two additional skills: protect and death
The protect skill can prevent the tank from any possible hits from other players;
The death skill can fire with deathball that can directly set others' unit to death (wow, so cool, thus it has to be punished by half the health off)