### PR TITLE
事件队列改进

### DIFF
--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -319,3 +319,4 @@ std::vector<const char *> GameCore::GetSelectableUnitList() const {
   return result;
 }
 }  // namespace battle_game
+

--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -319,4 +319,3 @@ std::vector<const char *> GameCore::GetSelectableUnitList() const {
   return result;
 }
 }  // namespace battle_game
-

--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -214,8 +214,8 @@ void GameCore::PushEventDealDamage(uint32_t dst_unit_id,
                                    uint32_t src_unit_id,
                                    float damage) {
   auto unit = GetUnit(dst_unit_id);
-  unit->health_change_-=damage / unit->GetMaxHealth();
-  unit->damage_record_[src_unit_id]+=damage;
+  unit->health_change_ -= damage / unit->GetMaxHealth();
+  unit->damage_record_[src_unit_id] += damage;
 }
 
 void GameCore::PushEventRemoveObstacle(uint32_t obstacle_id) {

--- a/src/battle_game/core/unit.cpp
+++ b/src/battle_game/core/unit.cpp
@@ -118,6 +118,36 @@ void Unit::RenderLifeBar() {
 void Unit::RenderHelper() {
 }
 
+uint32_t Unit::MaxDamage() {
+  float max_damage = .0f;
+  uint32_t unit_id;
+  for (auto i : damage_record_)
+    if (i.second > max_damage) {
+      unit_id = i.first;
+      max_damage = i.second;
+    }
+  return unit_id;
+}
+
+void Unit::EndTick() {
+  health_ += health_change_;
+  if (health_ < .0f)
+    game_core_->PushEventKillUnit(GetId(), MaxDamage());
+  else if (health_ > 1.0f)
+    health_ = 1.0f;
+
+  if (!game_core_->IsBlockedByObstacles(position_ + position_change_) &&
+      !game_core_->IsOutOfRange(position_ + position_change_))
+    position_ += position_change_;
+
+  rotation_ += rotation_change_;
+
+  health_change_=.0f;
+  position_change_={.0f,.0f};
+  rotation_change_=.0f;
+  damage_record_.clear();
+}
+
 const char *Unit::UnitName() const {
   return "Unknown Unit";
 }

--- a/src/battle_game/core/unit.cpp
+++ b/src/battle_game/core/unit.cpp
@@ -142,9 +142,9 @@ void Unit::EndTick() {
 
   rotation_ += rotation_change_;
 
-  health_change_=.0f;
-  position_change_={.0f,.0f};
-  rotation_change_=.0f;
+  health_change_ = .0f;
+  position_change_ = {.0f, .0f};
+  rotation_change_ = .0f;
   damage_record_.clear();
 }
 

--- a/src/battle_game/core/unit.h
+++ b/src/battle_game/core/unit.h
@@ -84,6 +84,14 @@ class Unit : public Object {
     return skills_;
   }
 
+  uint32_t MaxDamage();
+  void EndTick();
+
+  glm::vec2 position_change_{glm::vec2(.0f,.0f)};
+  float rotation_change_{.0f};
+  float health_change_{.0f};
+  std::map<uint32_t, float> damage_record_;
+
  protected:
   uint32_t player_id_{};
   float health_{1.0f};

--- a/src/battle_game/core/unit.h
+++ b/src/battle_game/core/unit.h
@@ -87,7 +87,7 @@ class Unit : public Object {
   uint32_t MaxDamage();
   void EndTick();
 
-  glm::vec2 position_change_{glm::vec2(.0f,.0f)};
+  glm::vec2 position_change_{glm::vec2(.0f, .0f)};
   float rotation_change_{.0f};
   float health_change_{.0f};
   std::map<uint32_t, float> damage_record_;


### PR DESCRIPTION
解决 #427。

对于 Unit，新增以下变量存储回合内 `health`、`position`、`rotation`的增量：
```cpp
glm::vec2 position_change_;
float health_change_;
float rotation_change;
```
修改 `game_core.cpp` 中如下函数，改为直接向对应增量修改：
```cpp
void GameCore::PushEventDealDamage(uint32_t dst_unit_id,
                                   uint32_t src_unit_id,
                                   float damage);
void GameCore::PushEventMoveUnit(uint32_t unit_id, glm::vec2 new_position);
void GameCore::PushEventRotateUnit(uint32_t unit_id, float new_rotation);
```
由于伤害混合计算，死亡时将凶手定义为**回合内最大伤害来源**。
对于 Unit，新增如下成员变量，调用 `PushEventDealDamage` 时记录对应 unit_id 造成的回合总伤害：
```cpp
std::map<uint32_t, float> damage_record_;
```
对 Unit 建立 `MaxDamge` 成员函数统计回合内最大伤害来源。

回合结束时需要对每个单位进行判定，因此对 Unit 新增 `TickEnd()` 函数。
该函数将回合内的增量并入单位状态，同时判定是否死亡、目标位置是否有障碍物或在地图边界内。
最后，将所有增量和伤害记录清除。