### PR TITLE
[Task4] finish issue 458 and 346

### DIFF
--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -53,6 +53,7 @@ void GameCore::GeneratePrimaryUnitList() {
   ADD_SELECTABLE_UNIT(unit::CritTank);
   ADD_SELECTABLE_UNIT(unit::Railgun);
   ADD_SELECTABLE_UNIT(unit::Udongein);
+  ADD_SELECTABLE_UNIT(unit::Arknights);
 
   unit.reset();
 }

--- a/src/battle_game/core/selectable_units.cpp
+++ b/src/battle_game/core/selectable_units.cpp
@@ -30,9 +30,11 @@ void GameCore::GeneratePrimaryUnitList() {
    * TODO: Add Your Unit Here!
    * */
   ADD_SELECTABLE_UNIT(unit::InfernoTank);
+  ADD_SELECTABLE_UNIT(unit::RoundUFO);
   ADD_SELECTABLE_UNIT(unit::Tank);
   ADD_SELECTABLE_UNIT(unit::DoubleScatterTank);
   ADD_SELECTABLE_UNIT(unit::ThreeBodyMan);
+  ADD_SELECTABLE_UNIT(unit::InfernoTank);
   ADD_SELECTABLE_UNIT(unit::LMTank);
   ADD_SELECTABLE_UNIT(unit::MissileTank);
   ADD_SELECTABLE_UNIT(unit::TripleShotTank);

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -90,7 +90,7 @@ bool Arknights::IsHit(glm::vec2 position) const {
   return Tank::IsHit(position);
 }
 
-void Arknights::operators() {
+void Arknights::GenerateBlock() {
   skills_[0].time_remain = operator_count_down_;
   if (operator_count_down_) {
     operator_count_down_--;

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -16,18 +16,15 @@ Arknights::Arknights(GameCore *game_core, uint32_t id, uint32_t player_id)
   if (!~tank_body_model_index) {
     auto mgr = AssetsManager::GetInstance();
     {
-      /* Tank Body */
+      /* Body */
       tank_body_model_index = mgr->RegisterModel(
           {
-              {{-0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{-0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              // distinguish front and back
-              {{0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{-0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.9f, 0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.9f, -0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.9f, 0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.9f, -0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
           },
-          {0, 1, 2, 1, 2, 3, 0, 2, 5, 2, 4, 5});
+          {0, 1, 2, 1, 2, 3});
     }
 
     {
@@ -80,40 +77,35 @@ void Arknights::Render() {
 }
 
 void Arknights::Update() {
-  ArknightsMove(3.0f, glm::radians(180.0f));
+  ArknightsMove(3.0f);
   TurretRotate();
   Fire();
 }
 
-void Arknights::ArknightsMove(float move_speed, float rotate_angular_speed) {
+void Arknights::ArknightsMove(float move_speed) {
   auto player = game_core_->GetPlayer(player_id_);
   if (player) {
     auto &input_data = player->GetInputData();
     glm::vec2 offset{0.0f};
-    if (input_data.key_down[GLFW_KEY_W]) {
+    if (input_data.key_down[GLFW_KEY_W] || input_data.key_down[GLFW_KEY_UP]) {
       offset.y += 1.0f;
     }
-    if (input_data.key_down[GLFW_KEY_S]) {
+    if (input_data.key_down[GLFW_KEY_S] || input_data.key_down[GLFW_KEY_DOWN]) {
       offset.y -= 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_A] || input_data.key_down[GLFW_KEY_LEFT]) {
+      offset.x -= 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_D] ||
+        input_data.key_down[GLFW_KEY_RIGHT]) {
+      offset.x += 1.0f;
     }
     float speed = move_speed * GetSpeedScale();
     offset *= kSecondPerTick * speed;
-    auto new_position =
-        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
-                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
-                              glm::vec4{offset, 0.0f, 0.0f}};
+    auto new_position = position_ + offset;
     if (!game_core_->IsBlockedByObstacles(new_position)) {
       game_core_->PushEventMoveUnit(id_, new_position);
     }
-    float rotation_offset = 0.0f;
-    if (input_data.key_down[GLFW_KEY_A]) {
-      rotation_offset += 1.0f;
-    }
-    if (input_data.key_down[GLFW_KEY_D]) {
-      rotation_offset -= 1.0f;
-    }
-    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
-    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
   }
 }
 
@@ -159,9 +151,8 @@ void Arknights::Fire() {
 
 bool Arknights::IsHit(glm::vec2 position) const {
   position = WorldToLocal(position);
-  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
-         position.y < 1.0f && position.x + position.y < 1.6f &&
-         position.y - position.x < 1.6f;
+  return position.x > -0.9f && position.x < 0.9f && position.y > -0.9f &&
+         position.y < 0.9f;
 }
 
 const char *Arknights::UnitName() const {

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -31,7 +31,7 @@ void Arknights::Update() {
   ArknightsMove(3.0f);
   TurretRotate();
   Fire();
-  operators();
+  GenerateBlock();
 }
 
 void Arknights::ArknightsMove(float move_speed) {

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -2,6 +2,7 @@
 
 #include "battle_game/core/bullets/bullets.h"
 #include "battle_game/core/game_core.h"
+#include "battle_game/core/obstacles/block.h"
 #include "battle_game/graphics/graphics.h"
 
 namespace battle_game::unit {
@@ -12,74 +13,25 @@ uint32_t tank_turret_model_index = 0xffffffffu;
 }  // namespace
 
 Arknights::Arknights(GameCore *game_core, uint32_t id, uint32_t player_id)
-    : Unit(game_core, id, player_id) {
-  if (!~tank_body_model_index) {
-    auto mgr = AssetsManager::GetInstance();
-    {
-      /* Body */
-      tank_body_model_index = mgr->RegisterModel(
-          {
-              {{-0.9f, 0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{0.9f, -0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{0.9f, 0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-              {{-0.9f, -0.9f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
-          },
-          {0, 1, 2, 1, 2, 3});
-    }
-
-    {
-      /* Tank Turret */
-      std::vector<ObjectVertex> turret_vertices;
-      std::vector<uint32_t> turret_indices;
-      const int precision = 60;
-      const float inv_precision = 1.0f / float(precision);
-      for (int i = 0; i < precision; i++) {
-        auto theta = (float(i) + 0.5f) * inv_precision;
-        theta *= glm::pi<float>() * 2.0f;
-        auto sin_theta = std::sin(theta);
-        auto cos_theta = std::cos(theta);
-        turret_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
-                                   {0.0f, 0.0f},
-                                   {0.7f, 0.7f, 0.7f, 1.0f}});
-        turret_indices.push_back(i);
-        turret_indices.push_back((i + 1) % precision);
-        turret_indices.push_back(precision);
-      }
-      turret_vertices.push_back(
-          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
-      turret_vertices.push_back(
-          {{-0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
-      turret_vertices.push_back(
-          {{0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
-      turret_vertices.push_back(
-          {{-0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
-      turret_vertices.push_back(
-          {{0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
-      turret_indices.push_back(precision + 1 + 0);
-      turret_indices.push_back(precision + 1 + 1);
-      turret_indices.push_back(precision + 1 + 2);
-      turret_indices.push_back(precision + 1 + 1);
-      turret_indices.push_back(precision + 1 + 2);
-      turret_indices.push_back(precision + 1 + 3);
-      tank_turret_model_index =
-          mgr->RegisterModel(turret_vertices, turret_indices);
-    }
-  }
+    : Tank(game_core, id, player_id) {
+  Skill temp;
+  temp.name = "operators";
+  temp.description = "release an obstacle";
+  temp.time_remain = 200;
+  temp.time_total = 500;
+  temp.type = E;
+  skills_.push_back(temp);
 }
 
 void Arknights::Render() {
-  battle_game::SetTransformation(position_, rotation_);
-  battle_game::SetTexture(0);
-  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
-  battle_game::DrawModel(tank_body_model_index);
-  battle_game::SetRotation(turret_rotation_);
-  battle_game::DrawModel(tank_turret_model_index);
+  Tank::Render();
 }
 
 void Arknights::Update() {
   ArknightsMove(3.0f);
   TurretRotate();
   Fire();
+  operators();
 }
 
 void Arknights::ArknightsMove(float move_speed) {
@@ -131,28 +83,38 @@ void Arknights::TurretRotate() {
 }
 
 void Arknights::Fire() {
-  if (fire_count_down_ == 0) {
-    auto player = game_core_->GetPlayer(player_id_);
-    if (player) {
-      auto &input_data = player->GetInputData();
-      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
-        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
-        GenerateBullet<bullet::CannonBall>(
-            position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
-            turret_rotation_, GetDamageScale(), velocity);
-        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
-      }
-    }
-  }
-  if (fire_count_down_) {
-    fire_count_down_--;
-  }
+  Tank::Fire();
 }
 
 bool Arknights::IsHit(glm::vec2 position) const {
-  position = WorldToLocal(position);
-  return position.x > -0.9f && position.x < 0.9f && position.y > -0.9f &&
-         position.y < 0.9f;
+  return Tank::IsHit(position);
+}
+
+void Arknights::operators() {
+  skills_[0].time_remain = operator_count_down_;
+  if (operator_count_down_) {
+    operator_count_down_--;
+  } else {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data1 = player->GetInputData();
+      if (input_data1.key_down[GLFW_KEY_E]) {
+        auto &input_data2 = player->GetInputData();
+        if (input_data2.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+          auto diff = input_data2.mouse_cursor_position - position_;
+          if (glm::length(diff) < 1) {
+            return;
+          } else {
+            auto new_position = position_ + diff;
+            float rotation = 0.0f;
+            game_core_->AddObstacle<battle_game::obstacle::Block>(new_position,
+                                                                  rotation);
+            operator_count_down_ = 6 * kTickPerSecond;
+          }
+        }
+      }
+    }
+  }
 }
 
 const char *Arknights::UnitName() const {

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -31,7 +31,7 @@ void Arknights::Update() {
   ArknightsMove(3.0f);
   TurretRotate();
   Fire();
-  GenerateBlock();
+  Operators();
 }
 
 void Arknights::ArknightsMove(float move_speed) {
@@ -90,7 +90,7 @@ bool Arknights::IsHit(glm::vec2 position) const {
   return Tank::IsHit(position);
 }
 
-void Arknights::GenerateBlock() {
+void Arknights::Operators() {
   skills_[0].time_remain = operator_count_down_;
   if (operator_count_down_) {
     operator_count_down_--;

--- a/src/battle_game/core/units/arknights_lc.cpp
+++ b/src/battle_game/core/units/arknights_lc.cpp
@@ -1,0 +1,174 @@
+#include "arknights_lc.h"
+
+#include "battle_game/core/bullets/bullets.h"
+#include "battle_game/core/game_core.h"
+#include "battle_game/graphics/graphics.h"
+
+namespace battle_game::unit {
+
+namespace {
+uint32_t tank_body_model_index = 0xffffffffu;
+uint32_t tank_turret_model_index = 0xffffffffu;
+}  // namespace
+
+Arknights::Arknights(GameCore *game_core, uint32_t id, uint32_t player_id)
+    : Unit(game_core, id, player_id) {
+  if (!~tank_body_model_index) {
+    auto mgr = AssetsManager::GetInstance();
+    {
+      /* Tank Body */
+      tank_body_model_index = mgr->RegisterModel(
+          {
+              {{-0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, 0.8f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{0.8f, -1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              // distinguish front and back
+              {{0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+              {{-0.6f, 1.0f}, {0.0f, 0.0f}, {1.0f, 1.0f, 1.0f, 1.0f}},
+          },
+          {0, 1, 2, 1, 2, 3, 0, 2, 5, 2, 4, 5});
+    }
+
+    {
+      /* Tank Turret */
+      std::vector<ObjectVertex> turret_vertices;
+      std::vector<uint32_t> turret_indices;
+      const int precision = 60;
+      const float inv_precision = 1.0f / float(precision);
+      for (int i = 0; i < precision; i++) {
+        auto theta = (float(i) + 0.5f) * inv_precision;
+        theta *= glm::pi<float>() * 2.0f;
+        auto sin_theta = std::sin(theta);
+        auto cos_theta = std::cos(theta);
+        turret_vertices.push_back({{sin_theta * 0.5f, cos_theta * 0.5f},
+                                   {0.0f, 0.0f},
+                                   {0.7f, 0.7f, 0.7f, 1.0f}});
+        turret_indices.push_back(i);
+        turret_indices.push_back((i + 1) % precision);
+        turret_indices.push_back(precision);
+      }
+      turret_vertices.push_back(
+          {{0.0f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 0.0f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{-0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_vertices.push_back(
+          {{0.1f, 1.2f}, {0.0f, 0.0f}, {0.7f, 0.7f, 0.7f, 1.0f}});
+      turret_indices.push_back(precision + 1 + 0);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 1);
+      turret_indices.push_back(precision + 1 + 2);
+      turret_indices.push_back(precision + 1 + 3);
+      tank_turret_model_index =
+          mgr->RegisterModel(turret_vertices, turret_indices);
+    }
+  }
+}
+
+void Arknights::Render() {
+  battle_game::SetTransformation(position_, rotation_);
+  battle_game::SetTexture(0);
+  battle_game::SetColor(game_core_->GetPlayerColor(player_id_));
+  battle_game::DrawModel(tank_body_model_index);
+  battle_game::SetRotation(turret_rotation_);
+  battle_game::DrawModel(tank_turret_model_index);
+}
+
+void Arknights::Update() {
+  ArknightsMove(3.0f, glm::radians(180.0f));
+  TurretRotate();
+  Fire();
+}
+
+void Arknights::ArknightsMove(float move_speed, float rotate_angular_speed) {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    glm::vec2 offset{0.0f};
+    if (input_data.key_down[GLFW_KEY_W]) {
+      offset.y += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_S]) {
+      offset.y -= 1.0f;
+    }
+    float speed = move_speed * GetSpeedScale();
+    offset *= kSecondPerTick * speed;
+    auto new_position =
+        position_ + glm::vec2{glm::rotate(glm::mat4{1.0f}, rotation_,
+                                          glm::vec3{0.0f, 0.0f, 1.0f}) *
+                              glm::vec4{offset, 0.0f, 0.0f}};
+    if (!game_core_->IsBlockedByObstacles(new_position)) {
+      game_core_->PushEventMoveUnit(id_, new_position);
+    }
+    float rotation_offset = 0.0f;
+    if (input_data.key_down[GLFW_KEY_A]) {
+      rotation_offset += 1.0f;
+    }
+    if (input_data.key_down[GLFW_KEY_D]) {
+      rotation_offset -= 1.0f;
+    }
+    rotation_offset *= kSecondPerTick * rotate_angular_speed * GetSpeedScale();
+    game_core_->PushEventRotateUnit(id_, rotation_ + rotation_offset);
+  }
+}
+
+float Arknights::GetSpeedScale() const {
+  return 0.9f;
+}
+
+float Arknights::GetHealthScale() const {
+  return 2.5f;
+}
+
+void Arknights::TurretRotate() {
+  auto player = game_core_->GetPlayer(player_id_);
+  if (player) {
+    auto &input_data = player->GetInputData();
+    auto diff = input_data.mouse_cursor_position - position_;
+    if (glm::length(diff) < 1e-4) {
+      turret_rotation_ = rotation_;
+    } else {
+      turret_rotation_ = std::atan2(diff.y, diff.x) - glm::radians(90.0f);
+    }
+  }
+}
+
+void Arknights::Fire() {
+  if (fire_count_down_ == 0) {
+    auto player = game_core_->GetPlayer(player_id_);
+    if (player) {
+      auto &input_data = player->GetInputData();
+      if (input_data.mouse_button_down[GLFW_MOUSE_BUTTON_LEFT]) {
+        auto velocity = Rotate(glm::vec2{0.0f, 20.0f}, turret_rotation_);
+        GenerateBullet<bullet::CannonBall>(
+            position_ + Rotate({0.0f, 1.2f}, turret_rotation_),
+            turret_rotation_, GetDamageScale(), velocity);
+        fire_count_down_ = kTickPerSecond;  // Fire interval 1 second.
+      }
+    }
+  }
+  if (fire_count_down_) {
+    fire_count_down_--;
+  }
+}
+
+bool Arknights::IsHit(glm::vec2 position) const {
+  position = WorldToLocal(position);
+  return position.x > -0.8f && position.x < 0.8f && position.y > -1.0f &&
+         position.y < 1.0f && position.x + position.y < 1.6f &&
+         position.y - position.x < 1.6f;
+}
+
+const char *Arknights::UnitName() const {
+  return "[kokodayo] Arknights";
+}
+
+const char *Arknights::Author() const {
+  return "liuchuan22";
+}
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/arknights_lc.h
+++ b/src/battle_game/core/units/arknights_lc.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "battle_game/core/unit.h"
+
+namespace battle_game::unit {
+class Arknights : public Unit {
+ public:
+  Arknights(GameCore *game_core, uint32_t id, uint32_t player_id);
+  void Render() override;
+  void Update() override;
+  float GetSpeedScale() const override;
+  float GetHealthScale() const override;
+  [[nodiscard]] bool IsHit(glm::vec2 position) const override;
+
+ protected:
+  void ArknightsMove(float move_speed, float rotate_angular_speed);
+  void TurretRotate();
+  void Fire();
+  [[nodiscard]] const char *UnitName() const override;
+  [[nodiscard]] const char *Author() const override;
+
+  float turret_rotation_{0.0f};
+  uint32_t fire_count_down_{0};
+  uint32_t mine_count_down_{0};
+};
+}  // namespace battle_game::unit

--- a/src/battle_game/core/units/arknights_lc.h
+++ b/src/battle_game/core/units/arknights_lc.h
@@ -1,8 +1,9 @@
 #pragma once
 #include "battle_game/core/unit.h"
+#include "battle_game/core/units/tiny_tank.h"
 
 namespace battle_game::unit {
-class Arknights : public Unit {
+class Arknights : public Tank {
  public:
   Arknights(GameCore *game_core, uint32_t id, uint32_t player_id);
   void Render() override;
@@ -15,11 +16,12 @@ class Arknights : public Unit {
   void ArknightsMove(float move_speed);
   void TurretRotate();
   void Fire();
+  void operators();
   [[nodiscard]] const char *UnitName() const override;
   [[nodiscard]] const char *Author() const override;
 
   float turret_rotation_{0.0f};
   uint32_t fire_count_down_{0};
-  uint32_t mine_count_down_{0};
+  uint32_t operator_count_down_{300};
 };
 }  // namespace battle_game::unit

--- a/src/battle_game/core/units/arknights_lc.h
+++ b/src/battle_game/core/units/arknights_lc.h
@@ -16,7 +16,7 @@ class Arknights : public Tank {
   void ArknightsMove(float move_speed);
   void TurretRotate();
   void Fire();
-  void operators();
+  void GenerateBlock();
   [[nodiscard]] const char *UnitName() const override;
   [[nodiscard]] const char *Author() const override;
 

--- a/src/battle_game/core/units/arknights_lc.h
+++ b/src/battle_game/core/units/arknights_lc.h
@@ -16,7 +16,7 @@ class Arknights : public Tank {
   void ArknightsMove(float move_speed);
   void TurretRotate();
   void Fire();
-  void GenerateBlock();
+  void Operators();
   [[nodiscard]] const char *UnitName() const override;
   [[nodiscard]] const char *Author() const override;
 

--- a/src/battle_game/core/units/arknights_lc.h
+++ b/src/battle_game/core/units/arknights_lc.h
@@ -12,7 +12,7 @@ class Arknights : public Unit {
   [[nodiscard]] bool IsHit(glm::vec2 position) const override;
 
  protected:
-  void ArknightsMove(float move_speed, float rotate_angular_speed);
+  void ArknightsMove(float move_speed);
   void TurretRotate();
   void Fire();
   [[nodiscard]] const char *UnitName() const override;

--- a/src/battle_game/core/units/inferno_tank.h
+++ b/src/battle_game/core/units/inferno_tank.h
@@ -22,7 +22,7 @@ class InfernoTank : public Tank {
 
   // float turret_rotation_{0.0f};
   uint32_t fire_count_down_{0};
-  uint32_t shoot_count_down_{240};
+  uint32_t shoot_count_down_{0};
   uint32_t hidden_count_down_{600};
   uint32_t block_count_down_{600};
   uint32_t isHidden{0};

--- a/src/battle_game/core/units/units.h
+++ b/src/battle_game/core/units/units.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "battle_game/core/units/Whaooooo_tank.h"
+#include "battle_game/core/units/arknights_lc.h"
 #include "battle_game/core/units/crit_tank.h"
 #include "battle_game/core/units/dark_fury.h"
 #include "battle_game/core/units/double_scatter_tank.h"


### PR DESCRIPTION
【issue 346】在tank move中单独加入WASD与UP-DOWN-RIGHT-LEFT的切换即可，修改后可以实现tank的四向移动（通过WASD或者UDRL均可操作），但是只能对于我的坦克有效，我没有找到一个更general的方法.[https://github.com/Yao-class-cpp-studio/battle_game/issues/346](url)
【issue 458】加入技能名operators, 同时按 E 和 鼠标左键 即可释放，在鼠标左键点击位置生成永久block，阻碍敌人移动并且挡子弹。[https://github.com/Yao-class-cpp-studio/battle_game/issues/458](url)