### PR TITLE
[Utility] Support online multi-player mode

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/abseil-cpp"]
 	path = external/abseil-cpp
 	url = https://github.com/abseil/abseil-cpp.git
+[submodule "external/asio"]
+	path = external/asio
+	url = https://github.com/chriskohlhoff/asio.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,4 +11,6 @@ add_subdirectory(external/abseil-cpp)
 list(APPEND BATTLE_GAME_EXTERNAL_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/external/abseil-cpp)
 list(APPEND BATTLE_GAME_EXTERNAL_INCLUDE_DIRS ${GRASSLAND_INCLUDE_DIRS})
 
+include_directories(external/asio/asio/include)
+
 add_subdirectory(src)

--- a/src/battle_game/app/app.cpp
+++ b/src/battle_game/app/app.cpp
@@ -137,7 +137,6 @@ void App::Start() {
   while (!input_data_queue_.empty()) {
     input_data_queue_.pop();
   }
-  input_data_synced_ = false;
   running_ = true;
   should_start_ = false;
 }
@@ -274,19 +273,17 @@ void App::UpdateDrawCommands() {
         1e-9;
     uint64_t target_update_step = std::lround(time_passed / kSecondPerTick);
     while (updated_step_ < target_update_step &&
-           (input_data_synced_ || !input_data_queue_.empty())) {
-      if (!input_data_synced_) {
+           (mode_ == kOffline || !input_data_queue_.empty())) {
+      if (!input_data_queue_.empty()) {
         const auto &data = input_data_queue_.front();
         for (uint32_t i = 1; i < data.size(); ++i) {
           game_core_->GetPlayer(i)->SetInputData(data[i].input_data);
           game_core_->GetPlayer(i)->SelectedUnit() = data[i].selected_unit;
         }
         input_data_queue_.pop();
-        input_data_synced_ = true;
       }
       game_core_->Update();
       updated_step_++;
-      input_data_synced_ = false;
     }
   }
   if (render_) {
@@ -337,7 +334,6 @@ void App::CaptureInput() {
   if (mode_ == kOffline) {
     game_core_->GetPlayer(my_player_id_)->SetInputData(input_data_);
     game_core_->GetPlayer(my_player_id_)->SelectedUnit() = selected_unit_;
-    input_data_synced_ = true;
   }
 }
 

--- a/src/battle_game/app/app.cpp
+++ b/src/battle_game/app/app.cpp
@@ -342,7 +342,6 @@ void App::SetScene() {
   if (mode_ == kOffline) {
     my_player_id_ = game_core_->AddPlayer();
     auto enemy_player_id = game_core_->AddPlayer();
-    game_core_->SetRenderPerspective(my_player_id_);
   } else if (mode_ == kClient) {
     if (client_) {
       uint32_t player_cnt = client_->GetPlayerCount();
@@ -356,6 +355,7 @@ void App::SetScene() {
   } else if (mode_ == kServer) {
     my_player_id_ = 0;
   }
+  game_core_->SetRenderPerspective(my_player_id_);
 }
 
 glm::mat4 App::GetCameraTransform(float fov_y) const {

--- a/src/battle_game/app/app.cpp
+++ b/src/battle_game/app/app.cpp
@@ -349,10 +349,16 @@ void App::CaptureInput() {
         glm::vec4{
             (glm::vec2{xpos, ypos} / glm::vec2{width, height}) * 2.0f - 1.0f,
             0.0f, 1.0f};
-    input_data_ = input_data;
+    {
+      std::lock_guard<std::mutex> lock(input_data_mutex_);
+      input_data_ = input_data;
+    }
   }
   if (mode_ == kOffline) {
-    game_core_->GetPlayer(my_player_id_)->SetInputData(input_data_);
+    {
+      std::lock_guard<std::mutex> lock(input_data_mutex_);
+      game_core_->GetPlayer(my_player_id_)->SetInputData(input_data_);
+    }
     game_core_->GetPlayer(my_player_id_)->SelectedUnit() = selected_unit_;
   }
 }

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -2,15 +2,18 @@
 #include "asio.hpp"
 #include "battle_game/app/app_settings.h"
 #include "battle_game/app/device_model.h"
+#include "battle_game/app/server.h"
 #include "battle_game/core/game_core.h"
 #include "battle_game/graphics/graphics.h"
 #include "grassland/grassland.h"
 
 namespace battle_game {
+constexpr uint16_t default_port = 8088;
+constexpr size_t max_ip_length = 50;
 using namespace grassland;
 class App {
  public:
-  enum Mode { kOffline, kClient, kServer, kServerNoRender };
+  enum Mode { kOffline, kClient, kServer };
 
   explicit App(const AppSettings &app_settings,
                GameCore *game_core,
@@ -18,10 +21,42 @@ class App {
   void Run(const Mode &mode = kOffline);
 
  private:
+  class Client : public std::enable_shared_from_this<Client> {
+   public:
+    Client(App *app);
+
+    void Connect(const asio::ip::tcp::resolver::results_type &endpoint);
+    void Close();
+    uint32_t GetPlayerCount() const;
+    uint32_t GetPlayerId() const;
+
+   private:
+    void DoReadHeader();
+    void DoReadBody();
+    void DoWrite();
+    void DoStart();
+    void DoStop();
+    void RegisterTimer();
+    void Write();
+    void Quit();
+
+    App *app_;
+    asio::io_context &io_context_;
+    asio::ip::tcp::socket socket_;
+    std::unique_ptr<asio::steady_timer> timer_;
+    std::queue<ByteString> write_messages_;
+    MessageInitial init_message_;
+    uint8_t buffer_[MessageInputData::length];
+    std::vector<MessageInputData> input_data_;
+  };
+
   void OnInit();
-  void OnReset(const Mode &mode);
   void OnLoop();
   void OnClose();
+
+  void Reset(const Mode &mode);
+  void Start();
+  void Stop();
 
   void OnUpdate();
   void OnRender();
@@ -58,11 +93,26 @@ class App {
 
   uint32_t my_player_id_{0};
   float fov_y_{10.0f};
-  bool should_reset_;
+  bool running_{false};
+  bool should_reset_{false};
+  bool should_start_{false};
   Mode mode_{kOffline}, chosen_mode_{kOffline};
+  bool render_{true};
   bool input_data_synced_;
+  std::queue<std::vector<MessageInputData>> input_data_queue_;
+  InputData input_data_;
+  int selected_unit_{0};
   std::chrono::time_point<std::chrono::steady_clock> begin_time_;
   uint64_t updated_step_{0};
+  uint16_t port_{default_port};
+  std::string message_{};
+  char ip_[max_ip_length]{"localhost"};
+
   asio::io_context &io_context_;
+  asio::executor_work_guard<asio::io_context::executor_type> worker_;
+  asio::ip::tcp::resolver resolver_;
+  std::thread thread_;
+  std::shared_ptr<Server> server_;
+  std::shared_ptr<Client> client_;
 };
 }  // namespace battle_game

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -50,7 +50,7 @@ class App {
     asio::io_context &io_context_;
     asio::ip::tcp::socket socket_;
     std::unique_ptr<asio::steady_timer> timer_;
-    std::queue<ByteString> write_messages_;
+    ByteString write_message_;
     MessageInitial init_message_;
     uint8_t buffer_[MessageInputData::length];
     CompleteInputData input_data_;

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -99,7 +99,6 @@ class App {
   bool should_start_{false};
   Mode mode_{kOffline}, chosen_mode_{kOffline};
   bool render_{true};
-  bool input_data_synced_;
   std::queue<std::vector<MessageInputData>> input_data_queue_;
   InputData input_data_;
   int selected_unit_{0};

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -1,4 +1,8 @@
 #pragma once
+#include <atomic>
+#include <mutex>
+#include <queue>
+
 #include "asio.hpp"
 #include "battle_game/app/app_settings.h"
 #include "battle_game/app/device_model.h"
@@ -105,7 +109,8 @@ class App {
   std::queue<CompleteInputData> input_data_queue_;
   std::mutex input_data_queue_mutex_;
   std::atomic<bool> input_data_queue_should_clear_{false};
-  std::atomic<InputData> input_data_{};
+  InputData input_data_{};
+  std::mutex input_data_mutex_;
   std::atomic<int> selected_unit_{0};
   std::atomic<std::chrono::time_point<std::chrono::steady_clock>> begin_time_;
   uint64_t updated_step_{0};

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "asio.hpp"
 #include "battle_game/app/app_settings.h"
 #include "battle_game/app/device_model.h"
 #include "battle_game/core/game_core.h"
@@ -9,11 +10,16 @@ namespace battle_game {
 using namespace grassland;
 class App {
  public:
-  explicit App(const AppSettings &app_settings, GameCore *game_core);
-  void Run();
+  enum Mode { kOffline, kClient, kServer, kServerNoRender };
+
+  explicit App(const AppSettings &app_settings,
+               GameCore *game_core,
+               asio::io_context &io_context);
+  void Run(const Mode &mode = kOffline);
 
  private:
   void OnInit();
+  void OnReset(const Mode &mode);
   void OnLoop();
   void OnClose();
 
@@ -52,5 +58,11 @@ class App {
 
   uint32_t my_player_id_{0};
   float fov_y_{10.0f};
+  bool should_reset_;
+  Mode mode_{kOffline}, chosen_mode_{kOffline};
+  bool input_data_synced_;
+  std::chrono::time_point<std::chrono::steady_clock> begin_time_;
+  uint64_t updated_step_{0};
+  asio::io_context &io_context_;
 };
 }  // namespace battle_game

--- a/src/battle_game/app/app.h
+++ b/src/battle_game/app/app.h
@@ -37,6 +37,7 @@ class App {
     void DoStart();
     void DoStop();
     void RegisterTimer();
+    void CloseTimer();
     void Write();
     void Quit();
 

--- a/src/battle_game/app/client.cpp
+++ b/src/battle_game/app/client.cpp
@@ -22,8 +22,10 @@ void App::Client::Connect(const tcp::resolver::results_type &endpoint) {
 }
 
 void App::Client::Close() {
-  socket_.cancel();
-  socket_.close();
+  if (socket_.is_open()) {
+    socket_.cancel();
+    socket_.close();
+  }
   CloseTimer();
 }
 

--- a/src/battle_game/app/client.cpp
+++ b/src/battle_game/app/client.cpp
@@ -11,11 +11,11 @@ void App::Client::Connect(const tcp::resolver::results_type &endpoint) {
   asio::async_connect(socket_, endpoint,
                       [this, self](asio::error_code ec, tcp::endpoint) {
                         if (!ec) {
-                          app_->message_ = u8"连接成功";
+                          app_->SetMessage(u8"连接成功");
                           RegisterTimer();
                           DoReadHeader();
                         } else if (ec != asio::error::operation_aborted) {
-                          app_->message_ = u8"错误：" + ec.message();
+                          app_->SetMessage(u8"错误：" + ec.message());
                           Close();
                         }
                       });
@@ -44,7 +44,7 @@ uint32_t App::Client::GetPlayerId() const {
 }
 
 void App::Client::Quit() {
-  app_->message_ = u8"连接中断";
+  app_->SetMessage(u8"连接中断");
   app_->Stop();
   Close();
 }
@@ -74,7 +74,7 @@ void App::Client::DoReadHeader() {
 void App::Client::DoReadBody() {
   auto self(shared_from_this());
   if (input_data_.size() > GetPlayerCount()) {
-    app_->input_data_queue_.push(input_data_);
+    app_->AppendInputData(input_data_);
     DoReadHeader();
     return;
   }

--- a/src/battle_game/app/client.cpp
+++ b/src/battle_game/app/client.cpp
@@ -140,7 +140,11 @@ void App::Client::Write() {
   auto self(shared_from_this());
   asio::post(io_context_, [this, self]() {
     bool write_in_progress = !write_message_.empty();
-    write_message_ = MessageInputData(app_->selected_unit_, app_->input_data_);
+    {
+      std::lock_guard<std::mutex> lock(app_->input_data_mutex_);
+      write_message_ =
+          MessageInputData(app_->selected_unit_, app_->input_data_);
+    }
     if (!write_in_progress) {
       DoWrite();
     }

--- a/src/battle_game/app/message.cpp
+++ b/src/battle_game/app/message.cpp
@@ -1,0 +1,70 @@
+#include "battle_game/app/message.h"
+
+#include <string>
+
+namespace battle_game {
+MessageInitial::MessageInitial() : player_cnt(0u), player_id(0u) {
+}
+MessageInitial::MessageInitial(uint32_t player_cnt, uint32_t player_id)
+    : player_cnt(player_cnt), player_id(player_id) {
+}
+MessageInitial::MessageInitial(const uint8_t *message)
+    : player_cnt(message[0]), player_id(message[1]) {
+}
+MessageInitial::operator ByteString() const {
+  ByteString result;
+  result.resize(2);
+  result[0] = player_cnt;
+  result[1] = player_id;
+  return result;
+}
+
+MessageInputData::MessageInputData() : selected_unit(0u), input_data{} {
+  std::memset(input_data.key_down, 0, sizeof(input_data.key_down));
+  std::memset(input_data.mouse_button_down, 0,
+              sizeof(input_data.mouse_button_down));
+  std::memset(input_data.mouse_button_clicked, 0,
+              sizeof(input_data.mouse_button_clicked));
+}
+MessageInputData::MessageInputData(uint32_t selected_unit,
+                                   const InputData &input_data)
+    : selected_unit(selected_unit), input_data(input_data) {
+}
+MessageInputData::MessageInputData(const uint8_t *message)
+    : selected_unit(message[0]) {
+  size_t totbit = 8u;
+  for (size_t i = 0; i < kKeyRange; ++i, ++totbit) {
+    input_data.key_down[i] = (message[totbit >> 3] >> (totbit & 7)) & 1;
+  }
+  for (size_t i = 0; i < kMouseButtonRange; ++i, ++totbit) {
+    input_data.mouse_button_down[i] =
+        (message[totbit >> 3] >> (totbit & 7)) & 1;
+  }
+  for (size_t i = 0; i < kMouseButtonRange; ++i, ++totbit) {
+    input_data.mouse_button_clicked[i] =
+        (message[totbit >> 3] >> (totbit & 7)) & 1;
+  }
+  memcpy(&input_data.mouse_cursor_position, message + ((totbit - 1) >> 3) + 1,
+         sizeof(glm::vec2));
+}
+MessageInputData::operator ByteString() const {
+  uint8_t result[length]{};
+  size_t totbit = 8u;
+  memset(result, 0, sizeof(result));
+  result[0] = selected_unit;
+  for (size_t i = 0; i < kKeyRange; ++i, ++totbit) {
+    result[totbit >> 3] |= (input_data.key_down[i] ? 1u : 0u) << (totbit & 7);
+  }
+  for (size_t i = 0; i < kMouseButtonRange; ++i, ++totbit) {
+    result[totbit >> 3] |= (input_data.mouse_button_down[i] ? 1u : 0u)
+                           << (totbit & 7);
+  }
+  for (size_t i = 0; i < kMouseButtonRange; ++i, ++totbit) {
+    result[totbit >> 3] |= (input_data.mouse_button_clicked[i] ? 1u : 0u)
+                           << (totbit & 7);
+  }
+  memcpy(result + ((totbit - 1) >> 3) + 1, &input_data.mouse_cursor_position,
+         sizeof(glm::vec2));
+  return ByteString(result, length);
+}
+}  // namespace battle_game

--- a/src/battle_game/app/message.cpp
+++ b/src/battle_game/app/message.cpp
@@ -1,6 +1,6 @@
 #include "battle_game/app/message.h"
 
-#include <string>
+#include <cstring>
 
 namespace battle_game {
 MessageInitial::MessageInitial() : player_cnt(0u), player_id(0u) {
@@ -44,13 +44,13 @@ MessageInputData::MessageInputData(const uint8_t *message)
     input_data.mouse_button_clicked[i] =
         (message[totbit >> 3] >> (totbit & 7)) & 1;
   }
-  memcpy(&input_data.mouse_cursor_position, message + ((totbit - 1) >> 3) + 1,
-         sizeof(glm::vec2));
+  std::memcpy(&input_data.mouse_cursor_position,
+              message + ((totbit - 1) >> 3) + 1, sizeof(glm::vec2));
 }
 MessageInputData::operator ByteString() const {
   uint8_t result[length]{};
   size_t totbit = 8u;
-  memset(result, 0, sizeof(result));
+  std::memset(result, 0, sizeof(result));
   result[0] = selected_unit;
   for (size_t i = 0; i < kKeyRange; ++i, ++totbit) {
     result[totbit >> 3] |= (input_data.key_down[i] ? 1u : 0u) << (totbit & 7);
@@ -63,8 +63,8 @@ MessageInputData::operator ByteString() const {
     result[totbit >> 3] |= (input_data.mouse_button_clicked[i] ? 1u : 0u)
                            << (totbit & 7);
   }
-  memcpy(result + ((totbit - 1) >> 3) + 1, &input_data.mouse_cursor_position,
-         sizeof(glm::vec2));
+  std::memcpy(result + ((totbit - 1) >> 3) + 1,
+              &input_data.mouse_cursor_position, sizeof(glm::vec2));
   return ByteString(result, length);
 }
 }  // namespace battle_game

--- a/src/battle_game/app/message.h
+++ b/src/battle_game/app/message.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <vector>
 
 #include "battle_game/core/input_data.h"
 
@@ -25,4 +26,6 @@ struct MessageInputData {
   uint32_t selected_unit;
   InputData input_data;
 };
+
+typedef std::vector<MessageInputData> CompleteInputData;
 }  // namespace battle_game

--- a/src/battle_game/app/message.h
+++ b/src/battle_game/app/message.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <string>
+
+#include "battle_game/core/input_data.h"
+
+namespace battle_game {
+typedef std::basic_string<uint8_t> ByteString;
+
+struct MessageInitial {
+  MessageInitial();
+  MessageInitial(uint32_t player_cnt, uint32_t player_id);
+  MessageInitial(const uint8_t *message);
+  operator ByteString() const;
+  static constexpr size_t length = 2;
+  uint32_t player_cnt, player_id;
+};
+
+struct MessageInputData {
+  MessageInputData();
+  MessageInputData(uint32_t selected_unit, const InputData &input_data);
+  MessageInputData(const uint8_t *message);
+  operator ByteString() const;
+  static constexpr size_t length =
+      1 + ((kKeyRange + kMouseButtonRange * 2 + 7) >> 3) + sizeof(glm::vec2);
+  uint32_t selected_unit;
+  InputData input_data;
+};
+}  // namespace battle_game

--- a/src/battle_game/app/server.cpp
+++ b/src/battle_game/app/server.cpp
@@ -1,0 +1,198 @@
+#include "battle_game/app/server.h"
+
+namespace battle_game {
+using asio::ip::tcp;
+Server::Participant::Participant(asio::ip::tcp::socket socket, Server &server)
+    : socket_(std::move(socket)), server_(server) {
+}
+
+void Server::Participant::Start() {
+  server_.Join(shared_from_this());
+  DoRead();
+}
+
+void Server::Participant::Close() {
+  socket_.close();
+}
+
+void Server::Participant::Deliver(const ByteString &message) {
+  bool write_in_progress = !write_messages_.empty();
+  write_messages_.push(message);
+  if (!write_in_progress) {
+    DoWrite();
+  }
+}
+
+uint32_t Server::Participant::GetPlayerId() const {
+  return player_id_;
+}
+void Server::Participant::SetPlayerId(uint32_t player_id) {
+  player_id_ = player_id;
+}
+const MessageInputData &Server::Participant::GetInputData() const {
+  return input_data_;
+}
+
+void Server::Participant::DoRead() {
+  auto self(shared_from_this());
+  asio::async_read(socket_, asio::buffer(buffer_, MessageInputData::length),
+                   [this, self](asio::error_code ec, std::size_t /*length*/) {
+                     if (!ec) {
+                       input_data_ = buffer_;
+                       if (player_id_) {
+                         server_.input_data_[player_id_] = input_data_;
+                       }
+                       DoRead();
+                     } else {
+                       server_.Leave(shared_from_this());
+                     }
+                   });
+}
+
+void Server::Participant::DoWrite() {
+  auto self(shared_from_this());
+  asio::async_write(socket_,
+                    asio::buffer(write_messages_.front().data(),
+                                 write_messages_.front().length()),
+                    [this, self](asio::error_code ec, std::size_t /*length*/) {
+                      if (!ec) {
+                        write_messages_.pop();
+                        if (!write_messages_.empty()) {
+                          DoWrite();
+                        }
+                      } else {
+                        server_.Leave(shared_from_this());
+                      }
+                    });
+}
+
+Server::Server(asio::io_context &io_context,
+               const tcp::endpoint &endpoint,
+               std::queue<std::vector<MessageInputData>> *input_data_queue)
+    : io_context_(io_context),
+      acceptor_(io_context, endpoint),
+      player_cnt_(0),
+      input_data_queue_(input_data_queue) {
+}
+
+void Server::Build() {
+  DoAccept();
+}
+
+void Server::Close() {
+  acceptor_.cancel();
+  acceptor_.close();
+  if (timer_) {
+    timer_->cancel();
+    timer_.reset();
+  }
+}
+
+void Server::Join(ParticipantPtr participant) {
+  participants_.insert(participant);
+}
+
+void Server::Leave(ParticipantPtr participant) {
+  if (participant->GetPlayerId()) {
+    input_data_[participant->GetPlayerId()].input_data = InputData();
+  }
+  participant->Close();
+  participants_.erase(participant);
+}
+
+void Server::DoAccept() {
+  auto self(shared_from_this());
+  acceptor_.async_accept([this, self](asio::error_code ec, tcp::socket socket) {
+    if (!ec) {
+      std::make_shared<Participant>(std::move(socket), *this)->Start();
+    }
+    DoAccept();
+  });
+}
+
+bool Server::IsRunning() const {
+  return running_;
+}
+
+void Server::Start() {
+  auto self(shared_from_this());
+  asio::post(io_context_, [this, self]() {
+    player_cnt_ = participants_.size();
+    if (player_cnt_ > kMaxPlayerNumber) {
+      player_cnt_ = 0;
+      return;
+    }
+    uint32_t current_id = 0;
+    input_data_.resize(player_cnt_ + 1);
+    for (auto participant : participants_) {
+      participant->SetPlayerId(++current_id);
+      input_data_[current_id] = participant->GetInputData();
+      participant->Deliver((uint8_t)'{' +
+                           ByteString(MessageInitial(player_cnt_, current_id)));
+    }
+    running_ = true;
+    timer_ = std::make_unique<asio::steady_timer>(
+        io_context_, asio::chrono::nanoseconds(
+                         (long long)std::roundl(1e9 * kSecondPerTick * 0.9f)));
+    RegisterBroadcast();
+  });
+}
+
+void Server::Stop() {
+  auto self(shared_from_this());
+  asio::post(io_context_, [this, self]() {
+    if (timer_) {
+      timer_->cancel();
+      timer_.reset();
+    }
+    Deliver({(uint8_t)'}'});
+    for (auto participant : participants_) {
+      participant->SetPlayerId(0);
+    }
+    input_data_.clear();
+    running_ = false;
+    player_cnt_ = 0;
+  });
+}
+
+void Server::RegisterBroadcast() {
+  auto self(shared_from_this());
+  timer_->async_wait([this, self](asio::error_code ec) {
+    if (!ec) {
+      if (timer_) {
+        timer_->cancel();
+        timer_.reset();
+      }
+      timer_ = std::make_unique<asio::steady_timer>(
+          io_context_, asio::chrono::nanoseconds(
+                           (long long)std::roundl(1e9 * kSecondPerTick)));
+      Broadcast();
+      RegisterBroadcast();
+    }
+  });
+}
+
+void Server::Broadcast() {
+  if (!running_) {
+    return;
+  }
+  if (input_data_queue_) {
+    input_data_queue_->push(input_data_);
+  }
+  ByteString message{};
+  message.reserve(1 + MessageInputData::length * player_cnt_);
+  message += (uint8_t)':';
+  for (uint32_t i = 1; i <= player_cnt_; ++i) {
+    message += input_data_[i];
+  }
+  Deliver(message);
+}
+
+void Server::Deliver(const ByteString &message) {
+  for (auto participant : participants_) {
+    if (participant->GetPlayerId()) {
+      participant->Deliver(message);
+    }
+  }
+}
+}  // namespace battle_game

--- a/src/battle_game/app/server.cpp
+++ b/src/battle_game/app/server.cpp
@@ -12,8 +12,10 @@ void Server::Participant::Start() {
 }
 
 void Server::Participant::Close() {
-  socket_.cancel();
-  socket_.close();
+  if (socket_.is_open()) {
+    socket_.cancel();
+    socket_.close();
+  }
 }
 
 void Server::Participant::Deliver(const ByteString &message) {

--- a/src/battle_game/app/server.h
+++ b/src/battle_game/app/server.h
@@ -38,7 +38,7 @@ class Server : public std::enable_shared_from_this<Server> {
     void DoWrite();
 
     asio::ip::tcp::socket socket_;
-    std::queue<ByteString> write_messages_;
+    ByteString write_messages_;
     MessageInputData input_data_{};
     Server &server_;
     uint32_t player_id_{0};

--- a/src/battle_game/app/server.h
+++ b/src/battle_game/app/server.h
@@ -1,0 +1,65 @@
+#pragma once
+#include <queue>
+#include <set>
+#include <vector>
+
+#include "asio.hpp"
+#include "battle_game/app/message.h"
+#include "battle_game/core/game_core.h"
+
+namespace battle_game {
+constexpr int kMaxPlayerNumber = 100;
+class Server : public std::enable_shared_from_this<Server> {
+ public:
+  Server(asio::io_context &io_context,
+         const asio::ip::tcp::endpoint &endpoint,
+         std::queue<std::vector<MessageInputData>> *input_data_queue = nullptr);
+
+  void Build();
+  void Close();
+  bool IsRunning() const;
+  void Start();
+  void Stop();
+
+ private:
+  class Participant : public std::enable_shared_from_this<Participant> {
+   public:
+    Participant(asio::ip::tcp::socket socket, Server &server);
+    void Start();
+    void Close();
+    void Deliver(const ByteString &message);
+    uint32_t GetPlayerId() const;
+    void SetPlayerId(uint32_t player_id);
+    const MessageInputData &GetInputData() const;
+
+   private:
+    void DoRead();
+    void DoWrite();
+
+    asio::ip::tcp::socket socket_;
+    std::queue<ByteString> write_messages_;
+    MessageInputData input_data_{};
+    Server &server_;
+    uint32_t player_id_{0};
+    uint8_t buffer_[MessageInputData::length];
+  };
+
+  typedef std::shared_ptr<Participant> ParticipantPtr;
+
+  void DoAccept();
+  void RegisterBroadcast();
+  void Broadcast();
+  void Join(ParticipantPtr participant);
+  void Leave(ParticipantPtr participant);
+  void Deliver(const ByteString &message);
+
+  asio::io_context &io_context_;
+  asio::ip::tcp::acceptor acceptor_;
+  std::unique_ptr<asio::steady_timer> timer_;
+  std::set<ParticipantPtr> participants_;
+  std::vector<MessageInputData> input_data_;
+  std::queue<std::vector<MessageInputData>> *input_data_queue_;
+  bool running_{false};
+  uint32_t player_cnt_;
+};
+}  // namespace battle_game

--- a/src/battle_game/app/server.h
+++ b/src/battle_game/app/server.h
@@ -47,7 +47,8 @@ class Server : public std::enable_shared_from_this<Server> {
   typedef std::shared_ptr<Participant> ParticipantPtr;
 
   void DoAccept();
-  void RegisterBroadcast();
+  void RegisterTimer();
+  void CloseTimer();
   void Broadcast();
   void Join(ParticipantPtr participant);
   void Leave(ParticipantPtr participant);

--- a/src/battle_game/app/server.h
+++ b/src/battle_game/app/server.h
@@ -13,7 +13,8 @@ class Server : public std::enable_shared_from_this<Server> {
  public:
   Server(asio::io_context &io_context,
          const asio::ip::tcp::endpoint &endpoint,
-         std::queue<std::vector<MessageInputData>> *input_data_queue = nullptr);
+         std::function<void(const CompleteInputData &)> deliver_input_data =
+             nullptr);
 
   void Build();
   void Close();
@@ -58,9 +59,9 @@ class Server : public std::enable_shared_from_this<Server> {
   asio::ip::tcp::acceptor acceptor_;
   std::unique_ptr<asio::steady_timer> timer_;
   std::set<ParticipantPtr> participants_;
-  std::vector<MessageInputData> input_data_;
-  std::queue<std::vector<MessageInputData>> *input_data_queue_;
-  bool running_{false};
+  CompleteInputData input_data_;
+  std::function<void(const CompleteInputData &)> deliver_input_data_;
+  std::atomic<bool> running_{false};
   uint32_t player_cnt_;
 };
 }  // namespace battle_game

--- a/src/battle_game/app/server.h
+++ b/src/battle_game/app/server.h
@@ -1,7 +1,6 @@
 #pragma once
-#include <queue>
+#include <atomic>
 #include <set>
-#include <vector>
 
 #include "asio.hpp"
 #include "battle_game/app/message.h"

--- a/src/battle_game/battle_game.cpp
+++ b/src/battle_game/battle_game.cpp
@@ -1,11 +1,76 @@
+#include <iostream>
+
 #include "battle_game/app/app.h"
 #include "battle_game/core/game_core.h"
 #include "battle_game/graphics/graphics.h"
 
-int main() {
-  battle_game::GameCore game_core;
-  battle_game::AppSettings app_settings;
-  asio::io_context io_context;
-  battle_game::App app(app_settings, &game_core, io_context);
-  app.Run();
+using asio::ip::tcp;
+
+constexpr int max_length = 4096;
+
+void PrintUsage() {
+  std::printf("Usage: ./battle_game\n");
+  std::printf("       ./battle_game --server [<port>]\n");
+}
+
+int main(int argc, const char *argv[]) {
+  if (argc == 1) {
+    asio::io_context io_context;
+    battle_game::GameCore game_core;
+    battle_game::AppSettings app_settings;
+    battle_game::App app(app_settings, &game_core, io_context);
+    app.Run();
+  } else if (argc <= 3 && !std::strcmp(argv[1], "--server")) {
+    try {
+      asio::io_context io_context;
+      uint16_t port = battle_game::default_port;
+      if (argc == 3) {
+        if (sscanf(argv[2], "%hu", &port) != 1) {
+          throw std::invalid_argument("Invalid port number");
+        }
+      }
+      std::shared_ptr<battle_game::Server> server =
+          std::make_shared<battle_game::Server>(io_context,
+                                                tcp::endpoint(tcp::v4(), port));
+      server->Build();
+      std::printf("Start server at port %hu\n", port);
+      std::thread thread([&io_context]() { io_context.run(); });
+      static char line[max_length + 1];
+      for (;;) {
+        if (server->IsRunning()) {
+          std::printf(
+              "Type 'stop' to stop the game, 'quit' to stop the server\n> ");
+        } else {
+          std::printf(
+              "Type 'start' to start the game, 'quit' to stop the server\n> ");
+        }
+        if (!std::cin.getline(line, max_length) || !strcmp(line, "quit")) {
+          break;
+        }
+        if (server->IsRunning() && !strcmp(line, "stop")) {
+          server->Stop();
+          while (server->IsRunning())
+            ;
+          std::printf("Stopped\n");
+        } else if (!server->IsRunning() && !strcmp(line, "start")) {
+          server->Start();
+          while (!server->IsRunning())
+            ;
+          std::printf("Started\n");
+        }
+      }
+      if (server->IsRunning()) {
+        server->Stop();
+      }
+      server->Close();
+      io_context.stop();
+      thread.join();
+    } catch (std::exception &e) {
+      std::fprintf(stderr, "Error: %s\n", e.what());
+      return 1;
+    }
+  } else {
+    PrintUsage();
+  }
+  return 0;
 }

--- a/src/battle_game/battle_game.cpp
+++ b/src/battle_game/battle_game.cpp
@@ -5,6 +5,7 @@
 int main() {
   battle_game::GameCore game_core;
   battle_game::AppSettings app_settings;
-  battle_game::App app(app_settings, &game_core);
+  asio::io_context io_context;
+  battle_game::App app(app_settings, &game_core, io_context);
   app.Run();
 }

--- a/src/battle_game/core/game_core.cpp
+++ b/src/battle_game/core/game_core.cpp
@@ -15,6 +15,29 @@ GameCore::GameCore() {
   GeneratePrimaryUnitList();
 }
 
+void GameCore::Reset() {
+  units_.clear();
+  bullets_.clear();
+  particles_.clear();
+  obstacles_.clear();
+  players_.clear();
+  respawn_points_.clear();
+
+  while (!event_queue_.empty()) {
+    event_queue_.pop();
+  }
+
+  unit_index_ = 1;
+  bullet_index_ = 1;
+  particle_index_ = 1;
+  obstacle_index_ = 1;
+  player_index_ = 1;
+
+  random_device_.seed(0);
+
+  SetScene();
+}
+
 /*
  * Update for 1 game tick.
  * Order: obstacles, bullets, units, particles

--- a/src/battle_game/core/game_core.h
+++ b/src/battle_game/core/game_core.h
@@ -24,6 +24,8 @@ class GameCore {
  public:
   GameCore();
 
+  void Reset();
+
   void SetScene();
 
   template <class UnitType, class... Args>


### PR DESCRIPTION
In my implementation, the transmitted information is the users' input data, and all the computations are distributed to the clients.

You can start a server in the app window, or use
```shell
./battlegame --server [<port>]
```
where the default port is 8088.

Currently I've **only** tested the situation where **one player is connected to localhost and the server is run in the command line only**. Because it was for the first time that I wrote asynchronous program using multithread, I think it must contains many bugs (, so you are welcomed to rewrite the server/client parts). It seems that **the servers and clients sometimes crash**.

Something we can do later:
- [ ] Test and debug thoroughly;
- [ ] Document;
- [ ] Support both Big Endian and Little Endian machines (currently conversion from `glm::vec2` to bytes is directly using `memcpy`);
- [ ] Capture user's input in the ImGui window;
- [ ] Support both IPv4 and IPv6;
- [ ] Pure server with less dependencies (i.e. we can build a server without Vulkan and etc.);
- [ ] Any other utilities.
